### PR TITLE
部屋に参加済みの処理修正

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -109,7 +109,8 @@
       "Bash(ENV=development DEBUG_AUTH_LOGS=true make run)",
       "Bash(source .env)",
       "Bash(gh issue view:*)",
-      "mcp__playwright__browser_tab_new"
+      "mcp__playwright__browser_tab_new",
+      "mcp__serena__list_memories"
     ],
     "deny": []
   }

--- a/internal/handlers/rooms.go
+++ b/internal/handlers/rooms.go
@@ -435,7 +435,13 @@ func (h *RoomHandler) JoinRoom(w http.ResponseWriter, r *http.Request) {
 		}
 		// 他の部屋に既に参加している場合
 		if strings.HasPrefix(err.Error(), "OTHER_ROOM_ACTIVE:") {
-			http.Error(w, "既に別の部屋に参加しています", http.StatusConflict)
+			response := map[string]interface{}{
+				"error":   "OTHER_ROOM_ACTIVE",
+				"message": "既に別の部屋に参加しています",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusConflict)
+			json.NewEncoder(w).Encode(response)
 			return
 		}
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/templates/pages/rooms.tmpl
+++ b/templates/pages/rooms.tmpl
@@ -1140,14 +1140,20 @@
                   return
                 }
                 // 他の部屋に参加している場合の確認ダイアログ
-                const errorText = await response.text()
-                if (errorText.includes('既に別の部屋に参加しています')) {
+                if (errorData.error === 'OTHER_ROOM_ACTIVE') {
+                  this.closeModal()
                   this.showConfirmDialog = true
                   this.confirmRoomId = this.currentRoom.id
                   this.isJoining = false
                   return
                 }
-                throw new Error(errorText || '参加に失敗しました')
+                // 既に同じ部屋に参加している場合
+                if (errorData.redirect) {
+                  window.location.href = errorData.redirect
+                  this.isJoining = false
+                  return
+                }
+                throw new Error(errorData.message || '参加に失敗しました')
               } else if (response.status === 403) {
                 // ブロック関係による参加拒否
                 const errorData = await response.json()


### PR DESCRIPTION
## 修正内容
部屋に参加済みの時に、別の部屋に参加しようとするとエラーが表示されていた
参加モーダルの「参加する」ボタンを押したときに確認モーダルが表示されるように修正