### PR TITLE
部屋作成後に共有モーダルを表示する

### DIFF
--- a/docs/implement_logs/2026-06-16/01_部屋作成後の共有モーダル自動表示.md
+++ b/docs/implement_logs/2026-06-16/01_部屋作成後の共有モーダル自動表示.md
@@ -1,0 +1,70 @@
+# 部屋作成後の共有モーダル自動表示
+
+**実装時間**: 不明（コミット後にログを後追い作成）／精査・リファクタリング 約15分
+
+## 概要
+
+部屋作成成功後、作成した部屋の詳細画面に遷移し、自動的に共有モーダルを表示する機能を実装しました。ホストは部屋を作成した直後に共有URLを各種SNS等へ簡単にシェアできるようになります。
+
+## 背景
+
+従来は部屋作成後に詳細画面へ遷移するだけで、共有するには改めて「共有」ボタンを押す必要がありました。作成直後は参加者を集めるモチベーションが最も高いタイミングであるため、共有フローを自動表示することで参加者募集を促進します。
+
+## 実装内容
+
+### 変更ファイル
+- `internal/handlers/rooms.go`
+- `static/js/room-create-store.js`
+- `templates/components/room_detail_script.tmpl`
+
+### 変更箇所
+
+#### 1. CreateRoom API のレスポンス拡充（rooms.go）
+
+部屋作成成功時のレスポンスに `redirect` フィールドを追加し、`?share=created` クエリパラメータ付きの遷移先URLを返すようにしました。
+
+```go
+response := map[string]interface{}{
+    "message":  "ルームを作成しました",
+    "room_id":  room.ID.String(),
+    "room":     room,
+    "redirect": fmt.Sprintf("/rooms/%s?share=created", room.ID.String()),
+}
+```
+
+#### 2. 部屋作成フローの遷移ロジック（room-create-store.js）
+
+作成成功時に `redirect` URL へ遷移するよう修正。`redirect` が未設定の場合のフォールバック（`room_id` からURLを組み立て）も追加し、後方互換性を確保しています。
+
+#### 3. 部屋詳細画面での自動表示（room_detail_script.tmpl）
+
+- `consumeCreatedShareFlag()`: URLの `share=created` パラメータを検知して削除（URL履歴を汚さないため `history.replaceState` を使用）
+- `prepareShareData()`: 共有データ生成を共通化（パスワード有無で分岐）
+- `openCreatedShareModal()`: 共有データを準備してモーダルを表示
+- `init()` の初期化完了後にフラグを消費してモーダルを自動表示
+
+## 特に注意した点
+
+- **ID使用ルール遵守**: リダイレクトURLは主キー `room.ID` を使用（`SupabaseUserID` 不使用）
+- **DRY原則**: 共有データ生成 `prepareShareData()` を共通化し、`openShare()` と `openCreatedShareModal()` で再利用
+- **URLのクリーンアップ**: `share=created` パラメータは履歴に残さないよう `replaceState` で削除（リロード時の再表示を防止）
+- **後方互換性**: `redirect` 未設定時のフォールバックを実装
+
+## 精査での追加リファクタリング（コミット後）
+
+初回コミット後にルール精査を行い、以下を追加修正しました。
+
+1. **メソッド命名の改善**: `shouldShowCreatedShareModal()` → `consumeCreatedShareFlag()` に改名。`should...` は真偽判定のみを期待させるが、実際にはURL書き換えの副作用を持つため、単一責任・驚き最小の原則に従い副作用を名前に反映しました。
+2. **変数の重複解消**: `room-create-store.js` で `roomId` を2回定義していたのを1箇所に統合しました。
+
+## テスト・動作確認
+
+- 部屋作成成功時に詳細画面へ遷移し、共有モーダルが自動表示されること
+- URLから `share=created` パラメータが除去されること（リロードで再表示されないこと）
+- パスワードあり部屋で共有メッセージに「※パスワード保護されています」が付与されること
+- 手動での「共有」ボタン押下時も従来通り動作すること
+
+## 今後の作業
+
+- モバイル実機での `navigator.share` 連動確認
+- 共有経由の参加者が想定通り増えるか、Analytics で効果計測

--- a/internal/handlers/rooms.go
+++ b/internal/handlers/rooms.go
@@ -328,9 +328,10 @@ func (h *RoomHandler) CreateRoom(w http.ResponseWriter, r *http.Request) {
 
 	// 作成成功時には部屋詳細URLを返す
 	response := map[string]interface{}{
-		"message": "ルームを作成しました",
-		"room_id": room.ID.String(),
-		"room":    room,
+		"message":  "ルームを作成しました",
+		"room_id":  room.ID.String(),
+		"room":     room,
+		"redirect": fmt.Sprintf("/rooms/%s?share=created", room.ID.String()),
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/static/js/room-create-store.js
+++ b/static/js/room-create-store.js
@@ -57,7 +57,6 @@ document.addEventListener('alpine:init', () => {
 
     // モーダルを開く
     async open() {
-
       // 認証チェック
       const authStore = Alpine.store('auth')
       if (!authStore.initialized || !authStore.isAuthenticated) {
@@ -146,7 +145,11 @@ document.addEventListener('alpine:init', () => {
 
     // フォームバリデーション
     get isValidForm() {
-      return this.formData.name.trim() && this.formData.gameVersionId && this.formData.maxPlayers
+      return (
+        this.formData.name.trim() &&
+        this.formData.gameVersionId &&
+        this.formData.maxPlayers
+      )
     },
 
     // 部屋作成処理
@@ -217,8 +220,11 @@ document.addEventListener('alpine:init', () => {
         // 成功時は部屋詳細画面に遷移
         this.close()
 
+        const roomId = result.room_id || result.room?.id || null
         if (result.redirect) {
           window.location.href = result.redirect
+        } else if (roomId) {
+          window.location.href = `/rooms/${roomId}?share=created`
         } else {
           window.location.reload()
         }

--- a/static/js/room-create-store.js
+++ b/static/js/room-create-store.js
@@ -207,9 +207,9 @@ document.addEventListener('alpine:init', () => {
         }
 
         const result = await response.json()
+        const roomId = result.room_id || result.room?.id || null
 
         if (window.Analytics && window.Analytics.isEnabled()) {
-          const roomId = result.room_id || result.room?.id || null
           window.Analytics.trackRoomCreate(
             roomId,
             this.formData.gameVersionId,
@@ -220,7 +220,6 @@ document.addEventListener('alpine:init', () => {
         // 成功時は部屋詳細画面に遷移
         this.close()
 
-        const roomId = result.room_id || result.room?.id || null
         if (result.redirect) {
           window.location.href = result.redirect
         } else if (roomId) {

--- a/templates/components/room_detail_script.tmpl
+++ b/templates/components/room_detail_script.tmpl
@@ -161,7 +161,7 @@ function roomDetail() {
       // チャットの最下部にスクロール
       this.$nextTick(() => this.scrollToBottom());
 
-      if (this.shouldShowCreatedShareModal()) {
+      if (this.consumeCreatedShareFlag()) {
         this.$nextTick(() => this.openCreatedShareModal());
       }
 
@@ -735,7 +735,7 @@ function roomDetail() {
       return this.shareMessages[randomIndex];
     },
 
-    shouldShowCreatedShareModal() {
+    consumeCreatedShareFlag() {
       const url = new URL(window.location.href);
       if (url.searchParams.get('share') !== 'created') {
         return false;

--- a/templates/components/room_detail_script.tmpl
+++ b/templates/components/room_detail_script.tmpl
@@ -161,6 +161,10 @@ function roomDetail() {
       // チャットの最下部にスクロール
       this.$nextTick(() => this.scrollToBottom());
 
+      if (this.shouldShowCreatedShareModal()) {
+        this.$nextTick(() => this.openCreatedShareModal());
+      }
+
       // ページを離れる時にSSE接続を閉じる
       window.addEventListener('beforeunload', () => {
         if (this.eventSource) {
@@ -731,10 +735,40 @@ function roomDetail() {
       return this.shareMessages[randomIndex];
     },
 
-    async openShare() {
+    shouldShowCreatedShareModal() {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('share') !== 'created') {
+        return false;
+      }
+
+      url.searchParams.delete('share');
+      const nextUrl = url.pathname + url.search + url.hash;
+      window.history.replaceState({}, '', nextUrl);
+      return true;
+    },
+
+    prepareShareData() {
       const hasPassword = {{ .PageData.Room.HasPassword }};
       const roomId = '{{ .PageData.Room.ID }}';
       const joinUrl = window.location.origin + '/rooms/' + roomId + '/join';
+
+      if (hasPassword) {
+        this.shareData.url = joinUrl;
+        this.shareData.text = this.getRandomShareMessage() + '\n※パスワード保護されています';
+      } else {
+        // 統一されたUX: パスワードなしでも/joinを使用
+        this.shareData.url = joinUrl;
+        this.shareData.text = this.getRandomShareMessage();
+      }
+    },
+
+    openCreatedShareModal() {
+      this.prepareShareData();
+      this.showShareModal = true;
+    },
+
+    async openShare() {
+      const hasPassword = {{ .PageData.Room.HasPassword }};
 
       if (hasPassword) {
         const confirmMessage =
@@ -746,14 +780,9 @@ function roomDetail() {
         if (!confirm(confirmMessage)) {
           return;
         }
-
-        this.shareData.url = joinUrl;
-        this.shareData.text = this.getRandomShareMessage() + '\n※パスワード保護されています';
-      } else {
-        // 統一されたUX: パスワードなしでも/joinを使用
-        this.shareData.url = joinUrl;
-        this.shareData.text = this.getRandomShareMessage();
       }
+
+      this.prepareShareData();
 
       if (this.isMobileDevice() && navigator.share) {
         try {


### PR DESCRIPTION
## 概要

部屋作成後に部屋詳細へ遷移し、初回表示時に既存の共有モーダルを自動表示するようにしました。

Closes #173

## 変更内容

- 部屋作成 API の成功レスポンスに共有モーダル起動用のリダイレクト URL を追加
- 部屋作成後のフロント側遷移で、詳細ページへ移動できるフォールバックを追加
- 部屋詳細ページで `share=created` を検知し、URL からパラメータを除去したうえで共有モーダルを表示
- 通常の共有ボタンで使う共有データ生成処理を共通化

## ユーザー影響

部屋を作成したユーザーが次に何をすればよいか迷いにくくなり、作成直後にそのまま募集リンクを共有できます。

## 検証

- `GOCACHE=/tmp/go-build go test ./...`
- `GOCACHE=/tmp/go-build go vet ./...`
- `./node_modules/.bin/prettier --check static/js/room-create-store.js templates/components/room_detail_script.tmpl`