### PR TITLE
AutoMigrate のモデル一覧を models.AllModels に一元化

### DIFF
--- a/docs/implement_logs/2026-08-20/01_マイグレーション一覧の一元化.md
+++ b/docs/implement_logs/2026-08-20/01_マイグレーション一覧の一元化.md
@@ -1,0 +1,38 @@
+# マイグレーションのモデル一覧を一元化（お知らせテーブル未作成の修正）
+
+**実装時間**: 約 15 分（10:15〜10:30 頃）
+
+## 概要
+
+お知らせ機能（#68 / PR #182）のデプロイ後、ステージング DB に `notifications` / `user_notification_states` テーブルが作成されていないことを発見し、修正しました。AutoMigrate のモデル一覧を `models.AllModels()` に一元化しています。
+
+## 原因
+
+AutoMigrate のモデル一覧が **3 箇所**にありました。
+
+| 場所 | 実際に使われるか |
+|---|---|
+| `internal/infrastructure/persistence/adapter.go` の `CommonMigrate` | **どこからも呼ばれていないデッドコード** |
+| `turso/db.go` の `commonMigrate()` | Turso で使用（実体） |
+| `postgres/db.go` の `commonMigrate()` | Postgres で使用（実体） |
+
+PR #182 では adapter.go のリストにだけ新モデルを追加していたため、実際のマイグレーションには含まれていませんでした。`rooms.dismissed_at`（#167）は既存モデル `Room` へのカラム追加だったため、実体リストの `&models.Room{}` 経由で問題なく適用されており、気づけませんでした。
+
+## 修正内容
+
+| ファイル | 変更 |
+|---|---|
+| `internal/models/all_models.go` (新規) | `AllModels()` — AutoMigrate 対象の全モデル（`Notification` / `UserNotificationState` を含む）をここだけで管理 |
+| `turso/db.go` / `postgres/db.go` | 各自のリストを `db.conn.AutoMigrate(models.AllModels()...)` に置き換え |
+| `adapter.go` | 未使用の `CommonMigrate` を削除（import 循環のため adapter 側に置けず使われていなかった） |
+
+## 検証
+
+- `go build` / `go vet` / `go test ./...` OK
+- ローカルから `go run cmd/migrate/main.go` をステージング DB（Turso）に対して実行し、`notifications` / `user_notification_states` テーブルと `idx_notifications_user_id_created_at` インデックスが作成されたことを確認（AutoMigrate は追加のみで安全、デプロイ時に実行される内容と同一）
+- ステージングは既にテーブルが作成済みのため、この修正のデプロイ前でもお知らせ機能は動作する。本番は本修正を含めてデプロイすれば `RUN_MIGRATION=true` で作成される
+
+## 再発防止
+
+- モデル一覧は今後 `models.AllModels()` の 1 箇所だけを更新すればよい
+- 教訓: 「AutoMigrate 対象への追加」はデプロイ後にテーブル存在確認までがセット（今回はステージング確認で発見できた）

--- a/internal/infrastructure/persistence/adapter.go
+++ b/internal/infrastructure/persistence/adapter.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"gorm.io/gorm"
-	"mhp-rooms/internal/models"
 )
 
 // DBAdapter はデータベースアダプターのインターフェース
@@ -27,29 +26,4 @@ type MigrationHelper interface {
 
 	// InsertInitialData は初期データを挿入
 	InsertInitialData(db *gorm.DB) error
-}
-
-// CommonMigrate はデータベース共通のマイグレーションを実行
-func CommonMigrate(db *gorm.DB) error {
-	// 共通のテーブル作成
-	return db.AutoMigrate(
-		&models.Platform{},
-		&models.GameVersion{},
-		&models.User{},
-		&models.Room{},
-		&models.RoomMember{},
-		&models.RoomMessage{},
-		&models.MessageReaction{},
-		&models.ReactionType{},
-		&models.UserBlock{},
-		&models.PlayerName{},
-		&models.UserFollow{},
-		&models.UserActivity{},
-		&models.RoomLog{},
-		&models.PasswordReset{},
-		&models.UserReport{},
-		&models.ReportAttachment{},
-		&models.Notification{},
-		&models.UserNotificationState{},
-	)
 }

--- a/internal/infrastructure/persistence/postgres/db.go
+++ b/internal/infrastructure/persistence/postgres/db.go
@@ -259,24 +259,6 @@ func (db *DB) insertInitialData() error {
 
 // commonMigrate はデータベース共通のマイグレーションを実行
 func (db *DB) commonMigrate() error {
-	// 共通のテーブル作成
-	return db.conn.AutoMigrate(
-		&models.Platform{},
-		&models.GameVersion{},
-		&models.User{},
-		&models.Room{},
-		&models.RoomMember{},
-		&models.RoomMessage{},
-		&models.MessageReaction{},
-		&models.ReactionType{},
-		&models.UserBlock{},
-		&models.PlayerName{},
-		&models.UserFollow{},
-		&models.UserActivity{},
-		&models.RoomLog{},
-		&models.PasswordReset{},
-		&models.UserReport{},
-		&models.ReportAttachment{},
-		&models.Contact{},
-	)
+	// 共通のテーブル作成（モデル一覧は models.AllModels で一元管理）
+	return db.conn.AutoMigrate(models.AllModels()...)
 }

--- a/internal/infrastructure/persistence/turso/db.go
+++ b/internal/infrastructure/persistence/turso/db.go
@@ -207,24 +207,6 @@ func (db *DB) insertInitialData() error {
 
 // commonMigrate はデータベース共通のマイグレーションを実行
 func (db *DB) commonMigrate() error {
-	// 共通のテーブル作成
-	return db.conn.AutoMigrate(
-		&models.Platform{},
-		&models.GameVersion{},
-		&models.User{},
-		&models.Room{},
-		&models.RoomMember{},
-		&models.RoomMessage{},
-		&models.MessageReaction{},
-		&models.ReactionType{},
-		&models.UserBlock{},
-		&models.PlayerName{},
-		&models.UserFollow{},
-		&models.UserActivity{},
-		&models.RoomLog{},
-		&models.PasswordReset{},
-		&models.UserReport{},
-		&models.ReportAttachment{},
-		&models.Contact{},
-	)
+	// 共通のテーブル作成（モデル一覧は models.AllModels で一元管理）
+	return db.conn.AutoMigrate(models.AllModels()...)
 }

--- a/internal/models/all_models.go
+++ b/internal/models/all_models.go
@@ -1,0 +1,27 @@
+package models
+
+// AllModels AutoMigrate 対象の全モデル。
+// マイグレーションのリストはここだけで管理する（turso / postgres で共用）
+func AllModels() []interface{} {
+	return []interface{}{
+		&Platform{},
+		&GameVersion{},
+		&User{},
+		&Room{},
+		&RoomMember{},
+		&RoomMessage{},
+		&MessageReaction{},
+		&ReactionType{},
+		&UserBlock{},
+		&PlayerName{},
+		&UserFollow{},
+		&UserActivity{},
+		&RoomLog{},
+		&PasswordReset{},
+		&UserReport{},
+		&ReportAttachment{},
+		&Contact{},
+		&Notification{},
+		&UserNotificationState{},
+	}
+}


### PR DESCRIPTION
## 概要

お知らせ機能（#68 / PR #182）で追加した `notifications` / `user_notification_states` テーブルが、デプロイしても作成されない問題の修正です。

Refs #68

## 原因

AutoMigrate のモデル一覧が 3 箇所にあり、PR #182 では **どこからも呼ばれていないデッドコード**（`persistence/adapter.go` の `CommonMigrate`）にだけ新モデルを追加していました。実際のマイグレーションは `turso/db.go` / `postgres/db.go` それぞれの `commonMigrate()` が持つ別リストで実行されるため、テーブルが作成されませんでした。

`rooms.dismissed_at`（#167）は既存モデル `Room` へのカラム追加だったため実体リスト経由で適用されており、気づけませんでした。

## 変更内容

- `internal/models/all_models.go` に `AllModels()` を新設し、AutoMigrate 対象の全モデル（`Notification` / `UserNotificationState` を含む）を **1 箇所で管理**
- `turso/db.go` / `postgres/db.go` の各リストを `AutoMigrate(models.AllModels()...)` に置き換え
- 未使用の `CommonMigrate` を削除（import 循環のため adapter 側には置けず、使われていなかった）

## 検証

- `go build ./...` / `go vet ./...` / `go test ./...`
- ローカルから `go run cmd/migrate/main.go` をステージング DB（Turso）に対して実行し、`notifications` / `user_notification_states` テーブルと `idx_notifications_user_id_created_at` インデックスの作成を確認（AutoMigrate は追加のみで、デプロイ時に実行される内容と同一）
- **ステージングは上記実行によりテーブル作成済みのため、お知らせ機能は現時点で動作可能**。本番は本修正を含むデプロイで作成される

## 実装ログ

`docs/implement_logs/2026-08-20/01_マイグレーション一覧の一元化.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
