### PR TITLE
Production Release 20260820-2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - Tailwind CSS (スタイリング)
 - **コンテナ**: Docker + Docker Compose
 - **デプロイ**: Google Cloud Run
+  - **ステージング**: https://stg.huntershub.net
+  - **本番**: https://huntershub.net
 
 ## プロジェクト構造
 

--- a/cmd/server/application.go
+++ b/cmd/server/application.go
@@ -33,6 +33,7 @@ type Application struct {
 	userHandler         *handlers.UserHandler
 	followHandler       *handlers.FollowHandler
 	notificationHandler *handlers.NotificationHandler
+	adminHandler        *handlers.AdminHandler
 	reportHandler       *handlers.ReportHandler
 	infoHandler         *handlers.InfoHandler
 	roadmapHandler      *handlers.RoadmapHandler
@@ -112,6 +113,7 @@ func (app *Application) initHandlers() error {
 	app.authMiddleware = authMiddleware
 
 	app.authHandler = handlers.NewAuthHandler(app.repo)
+	app.adminHandler = handlers.NewAdminHandler(app.repo)
 	app.roomHandler = handlers.NewRoomHandler(app.repo, app.sseHub)
 	app.roomDetailHandler = handlers.NewRoomDetailHandler(app.repo)
 	app.roomJoinHandler = handlers.NewRoomJoinHandler(app.repo)

--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -70,6 +70,7 @@ func (app *Application) SetupRoutes() chi.Router {
 		app.setupRoomRoutes(r)
 		app.setupAuthRoutes(r)
 		app.setupAPIRoutes(r)
+		app.setupAdminRoutes(r)
 	}
 
 	return r
@@ -171,6 +172,21 @@ func (app *Application) setupRoomRoutes(r chi.Router) {
 			rr.Post("/{id}/sse-token", app.sseTokenHandler.GenerateSSEToken)
 			rr.Get("/{id}/messages/stream", rmh.StreamMessages)
 		}
+	})
+}
+
+// setupAdminRoutes 管理者専用ルート。全環境で認証必須とし、権限がない場合は 404 を返す
+func (app *Application) setupAdminRoutes(r chi.Router) {
+	r.Route("/admin", func(ar chi.Router) {
+		if app.hasAuthMiddleware() {
+			ar.Use(app.authMiddleware.Middleware)
+		}
+		// 認証ミドルウェアがない環境でもコンテキストにユーザーが載らないため、RequireAdmin が 404 を返す
+		ar.Use(middleware.RequireAdmin)
+
+		ar.Get("/", app.adminHandler.Dashboard)
+		ar.Get("/rooms", app.adminHandler.Rooms)
+		ar.Get("/rooms/{id}", app.adminHandler.RoomDetail)
 	})
 }
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -57,6 +57,7 @@ GitHub
 
 | 項目 | ステージング | 本番 |
 |------|------------|------|
+| URL | https://stg.huntershub.net | https://huntershub.net |
 | Cloud Buildファイル | `cloudbuild.stg.yml` | `cloudbuild.yml` |
 | サービス名 | `huntershub-stg` | `huntershub` |
 | OGP Job名 | `ogp-renderer-stg` | `ogp-renderer` |

--- a/docs/implement_logs/2026-08-20/04_管理画面フェーズ1.md
+++ b/docs/implement_logs/2026-08-20/04_管理画面フェーズ1.md
@@ -1,0 +1,55 @@
+# 管理者向け管理画面フェーズ1（部屋・チャット閲覧、活動タイムライン）
+
+**実装時間**: 約1時間（2026-08-20）
+**Issue**: #192
+
+## 概要
+
+管理者（`users.role = 'admin'`）だけがアクセスできる閲覧専用の管理画面を追加した。通報対応や利用状況の把握のため、部屋のチャットログ・メンバー・全体の活動の流れを確認できる。
+
+- `GET /admin` … 活動タイムライン（RoomLog を新しい順、50件/ページ）
+- `GET /admin/rooms` … 全部屋一覧（解散済み含む、状態バッジ・ホストへの通報数付き、20件/ページ）
+- `GET /admin/rooms/{id}` … 部屋詳細（部屋情報 + メンバー + チャットログ、`?before=<uuid>` カーソルで過去へ遡り）
+
+## 設計判断
+
+- **一般導線の認可は一切緩めない**: `GetMessages` 等のメンバーチェックには手を入れず、管理画面はリポジトリから直接読む別ルート・別テンプレートとした（Issue #192 の方針どおり）
+- **RequireAdmin ミドルウェア**（`internal/middleware/admin.go`）: JWT 認証の後段でコンテキストの DB ユーザーの `Role` を確認。権限がない場合は管理画面の存在を隠すため **404** を返す
+- **全環境で認証必須**: 既存 rooms ルートにある「開発環境は認証なし」分岐は持ち込まない。認証ミドルウェアが無い環境でもコンテキストにユーザーが載らないため RequireAdmin が 404 を返す
+- **監査ログ**: 部屋詳細の閲覧ごとに `RoomLog(action="admin_view", user_id=管理者)` を記録。書き込み失敗時は閲覧は妨げないがエラーログを残す。admin_view はタイムラインにも表示される（管理者の行動も可視化される）
+- **通報数**: UserReport は部屋ではなくユーザーに紐づくため、「ホストユーザーへの通報数」を GROUP BY で取得して表示
+
+## 主な追加・変更
+
+- `internal/models/user.go`: `RoleUser` / `RoleAdmin` 定数と `IsAdmin()` を追加
+- `internal/middleware/admin.go`: `RequireAdmin`（新規）
+- `internal/repository/room_log_repository.go`: `RoomLogRepository`（CreateLog / ListRecentLogs / CountLogs、新規）
+- `internal/repository/room_repository.go`: `GetAllRoomsForAdmin` / `CountAllRooms` 追加
+- `internal/repository/report_repository.go`: `CountReportsByReportedUserIDs` 追加
+- `internal/handlers/admin.go`: AdminHandler（Dashboard / Rooms / RoomDetail）と表示用の純粋関数（`buildAdminLogRows` など）
+- `templates/components/admin_nav.tmpl` + `templates/pages/admin_{dashboard,rooms,room_detail}.tmpl`: `noindex` 付きの閲覧専用ページ
+- `cmd/server/routes.go`: `setupAdminRoutes`（/admin 配下、認証 + RequireAdmin）
+
+## 管理者の付与方法（当面）
+
+```sql
+-- turso db shell <database> で実行
+UPDATE users SET role = 'admin' WHERE email = '<管理者のメールアドレス>';
+```
+
+注意: 認証ミドルウェアのユーザーキャッシュが 5 分あるため、付与後は最大 5 分待つか再ログインする。
+
+## テスト
+
+- `internal/middleware/admin_test.go`: RequireAdmin（未認証 / 一般 / ロール空 / 管理者）
+- `internal/handlers/admin_test.go`: 状態ラベル・タイムライン行変換（JST 表示、システム実行者、未知アクション）・通報数マッピング・名前フォールバック・3 テンプレートの描画テスト
+- `go build ./...` / `go test ./internal/...` 全パス、gofmt / prettier 差分なし
+
+## 更新情報について
+
+管理者専用機能でユーザーに見える変更はないため、content/info/ への追記は行わない。
+
+## 今後の作業・改善点
+
+- プライバシーポリシーには第3条6項（規約違反ユーザーの特定目的）があるが、「運営が調査目的で投稿内容（チャット）を閲覧する場合がある」旨の明示はない。文言追加をユーザーに提案する
+- 将来の拡張（Issue #192 に記載）: admin 専用 SSE でのリアルタイム閲覧、通報一覧との連携、介入系操作、moderator ロール

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -1,0 +1,392 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"mhp-rooms/internal/middleware"
+	"mhp-rooms/internal/models"
+	"mhp-rooms/internal/repository"
+	"mhp-rooms/internal/view"
+)
+
+const (
+	adminLogsPerPage     = 50
+	adminRoomsPerPage    = 20
+	adminMessagesPerPage = 50
+
+	// AdminActionView 管理者による部屋閲覧の監査ログ用アクション
+	AdminActionView = "admin_view"
+)
+
+// adminJST 管理画面の日時表示用タイムゾーン
+var adminJST = time.FixedZone("JST", 9*60*60)
+
+// adminActionLabels RoomLog の action に対応する日本語ラベル
+var adminActionLabels = map[string]string{
+	"create":          "部屋作成",
+	"join":            "参加",
+	"leave":           "退出",
+	"kick":            "キック",
+	"update_settings": "設定変更",
+	"dismiss":         "解散",
+	"auto_dismiss":    "自動解散",
+	AdminActionView:   "管理者閲覧",
+}
+
+type AdminHandler struct {
+	repo *repository.Repository
+}
+
+// adminLogRow ダッシュボードのタイムライン1行分
+type adminLogRow struct {
+	CreatedAt   string
+	ActionLabel string
+	RoomID      uuid.UUID
+	RoomName    string
+	ActorName   string
+	Detail      string
+}
+
+// adminRoomRow 部屋一覧の1行分
+type adminRoomRow struct {
+	ID          uuid.UUID
+	Name        string
+	GameVersion string
+	HostName    string
+	Players     string
+	StatusLabel string
+	StatusClass string
+	ReportCount int64
+	CreatedAt   string
+}
+
+// adminMessageRow 部屋詳細のチャットログ1行分
+type adminMessageRow struct {
+	CreatedAt string
+	UserName  string
+	Message   string
+}
+
+// adminMemberRow 部屋詳細のメンバー1行分
+type adminMemberRow struct {
+	UserID   uuid.UUID
+	Name     string
+	IsHost   bool
+	JoinedAt string
+}
+
+// adminDashboardData ダッシュボードの PageData
+type adminDashboardData struct {
+	Logs       []adminLogRow
+	Pagination Pagination
+}
+
+// adminRoomsData 部屋一覧の PageData
+type adminRoomsData struct {
+	Rooms      []adminRoomRow
+	Pagination Pagination
+}
+
+// adminRoomDetailData 部屋詳細の PageData
+type adminRoomDetailData struct {
+	Room        *models.Room
+	StatusLabel string
+	StatusClass string
+	CreatedAt   string
+	DismissedAt string
+	Members     []adminMemberRow
+	Messages    []adminMessageRow
+	OlderCursor string
+}
+
+func NewAdminHandler(repo *repository.Repository) *AdminHandler {
+	return &AdminHandler{repo: repo}
+}
+
+// Dashboard 全部屋の操作ログを新しい順に表示するタイムライン
+func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
+	page := parsePageParam(r)
+
+	logs, err := h.repo.RoomLog.ListRecentLogs(adminLogsPerPage, (page-1)*adminLogsPerPage)
+	if err != nil {
+		http.Error(w, "ログの取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	total, err := h.repo.RoomLog.CountLogs()
+	if err != nil {
+		http.Error(w, "ログ件数の取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	data := adminDashboardData{
+		Logs:       buildAdminLogRows(logs),
+		Pagination: newPagination(total, page, adminLogsPerPage, "/admin"),
+	}
+
+	view.Template(w, "admin_dashboard.tmpl", view.Data{
+		Title:    "管理ダッシュボード",
+		PageData: data,
+	})
+}
+
+// Rooms 解散済みも含む全部屋の一覧
+func (h *AdminHandler) Rooms(w http.ResponseWriter, r *http.Request) {
+	page := parsePageParam(r)
+
+	rooms, err := h.repo.Room.GetAllRoomsForAdmin(adminRoomsPerPage, (page-1)*adminRoomsPerPage)
+	if err != nil {
+		http.Error(w, "部屋一覧の取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	total, err := h.repo.Room.CountAllRooms()
+	if err != nil {
+		http.Error(w, "部屋件数の取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	hostIDs := make([]uuid.UUID, 0, len(rooms))
+	seen := make(map[uuid.UUID]struct{}, len(rooms))
+	for _, room := range rooms {
+		if _, ok := seen[room.HostUserID]; ok {
+			continue
+		}
+		seen[room.HostUserID] = struct{}{}
+		hostIDs = append(hostIDs, room.HostUserID)
+	}
+
+	reportCounts, err := h.repo.Report.CountReportsByReportedUserIDs(hostIDs)
+	if err != nil {
+		// 通報数は補助情報のため、取得に失敗しても一覧表示は継続する
+		log.Printf("管理画面: 通報数の取得に失敗しました: %v", err)
+		reportCounts = map[uuid.UUID]int64{}
+	}
+
+	data := adminRoomsData{
+		Rooms:      buildAdminRoomRows(rooms, reportCounts),
+		Pagination: newPagination(total, page, adminRoomsPerPage, "/admin/rooms"),
+	}
+
+	view.Template(w, "admin_rooms.tmpl", view.Data{
+		Title:    "部屋一覧（管理）",
+		PageData: data,
+	})
+}
+
+// RoomDetail 部屋情報・メンバー・チャットログの閲覧専用ビュー。閲覧は監査ログに記録する
+func (h *AdminHandler) RoomDetail(w http.ResponseWriter, r *http.Request) {
+	roomID, err := uuid.Parse(chi.URLParam(r, "id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	room, err := h.repo.Room.FindRoomByID(roomID)
+	if err != nil || room == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	members, err := h.repo.Room.GetRoomMembers(roomID)
+	if err != nil {
+		members = []models.RoomMember{}
+	}
+
+	var beforeID *uuid.UUID
+	if beforeStr := r.URL.Query().Get("before"); beforeStr != "" {
+		if id, err := uuid.Parse(beforeStr); err == nil {
+			beforeID = &id
+		}
+	}
+
+	// 新しい順で取得し、チャットとして読めるよう古い順に並べ直す
+	messages, err := h.repo.RoomMessage.GetMessages(roomID, adminMessagesPerPage, beforeID)
+	if err != nil {
+		http.Error(w, "メッセージの取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	for i, j := 0, len(messages)-1; i < j; i, j = i+1, j-1 {
+		messages[i], messages[j] = messages[j], messages[i]
+	}
+
+	// さらに古いログがある場合のカーソル（表示中の最古メッセージID）
+	var olderCursor string
+	if len(messages) == adminMessagesPerPage {
+		olderCursor = messages[0].ID.String()
+	}
+
+	// 監査ログ: 誰がいつどの部屋を閲覧したかを記録する
+	if admin, ok := middleware.GetDBUserFromContext(r.Context()); ok && admin != nil {
+		auditLog := &models.RoomLog{
+			RoomID: roomID,
+			UserID: &admin.ID,
+			Action: AdminActionView,
+			Details: models.JSONB{
+				Data: map[string]interface{}{
+					"admin_name": adminUserName(&admin.ID, admin),
+				},
+			},
+		}
+		if err := h.repo.RoomLog.CreateLog(auditLog); err != nil {
+			// 監査ログの書き込み失敗は閲覧自体は妨げないが、必ず痕跡を残す
+			log.Printf("管理画面: 監査ログの記録に失敗しました room_id=%s admin_id=%s: %v", roomID, admin.ID, err)
+		}
+	}
+
+	statusLabel, statusClass := adminRoomStatus(room)
+	data := adminRoomDetailData{
+		Room:        room,
+		StatusLabel: statusLabel,
+		StatusClass: statusClass,
+		CreatedAt:   formatAdminTime(room.CreatedAt),
+		Members:     buildAdminMemberRows(members),
+		Messages:    buildAdminMessageRows(messages),
+		OlderCursor: olderCursor,
+	}
+	if room.DismissedAt != nil {
+		data.DismissedAt = formatAdminTime(*room.DismissedAt)
+	}
+
+	view.Template(w, "admin_room_detail.tmpl", view.Data{
+		Title:    fmt.Sprintf("%s（管理）", room.Name),
+		PageData: data,
+	})
+}
+
+// buildAdminLogRows RoomLog を表示用の行に変換する
+func buildAdminLogRows(logs []models.RoomLog) []adminLogRow {
+	rows := make([]adminLogRow, 0, len(logs))
+	for _, l := range logs {
+		label, ok := adminActionLabels[l.Action]
+		if !ok {
+			label = l.Action
+		}
+
+		roomName := l.Room.Name
+		if roomName == "" {
+			roomName = "（削除済みの部屋）"
+		}
+
+		rows = append(rows, adminLogRow{
+			CreatedAt:   formatAdminTime(l.CreatedAt),
+			ActionLabel: label,
+			RoomID:      l.RoomID,
+			RoomName:    roomName,
+			ActorName:   adminUserName(l.UserID, l.User),
+			Detail:      adminLogDetail(l.Details),
+		})
+	}
+	return rows
+}
+
+// buildAdminRoomRows Room を表示用の行に変換する（通報数はホストユーザーに対するもの）
+func buildAdminRoomRows(rooms []models.Room, reportCounts map[uuid.UUID]int64) []adminRoomRow {
+	rows := make([]adminRoomRow, 0, len(rooms))
+	for i := range rooms {
+		room := &rooms[i]
+		statusLabel, statusClass := adminRoomStatus(room)
+		rows = append(rows, adminRoomRow{
+			ID:          room.ID,
+			Name:        room.Name,
+			GameVersion: room.GameVersion.Code,
+			HostName:    adminUserName(&room.HostUserID, &room.Host),
+			Players:     fmt.Sprintf("%d/%d", room.CurrentPlayers, room.MaxPlayers),
+			StatusLabel: statusLabel,
+			StatusClass: statusClass,
+			ReportCount: reportCounts[room.HostUserID],
+			CreatedAt:   formatAdminTime(room.CreatedAt),
+		})
+	}
+	return rows
+}
+
+func buildAdminMemberRows(members []models.RoomMember) []adminMemberRow {
+	rows := make([]adminMemberRow, 0, len(members))
+	for i := range members {
+		m := &members[i]
+		rows = append(rows, adminMemberRow{
+			UserID:   m.UserID,
+			Name:     adminUserName(&m.UserID, &m.User),
+			IsHost:   m.IsHost,
+			JoinedAt: formatAdminTime(m.JoinedAt),
+		})
+	}
+	return rows
+}
+
+func buildAdminMessageRows(messages []models.RoomMessage) []adminMessageRow {
+	rows := make([]adminMessageRow, 0, len(messages))
+	for i := range messages {
+		m := &messages[i]
+		rows = append(rows, adminMessageRow{
+			CreatedAt: formatAdminTime(m.CreatedAt),
+			UserName:  adminUserName(&m.UserID, &m.User),
+			Message:   m.Message,
+		})
+	}
+	return rows
+}
+
+// adminRoomStatus 部屋の状態ラベルとバッジ用クラスを返す
+func adminRoomStatus(room *models.Room) (string, string) {
+	switch {
+	case !room.IsActive && room.DismissReason != nil && *room.DismissReason == models.DismissReasonInactive:
+		return "自動解散", "bg-gray-100 text-gray-600"
+	case !room.IsActive:
+		return "解散", "bg-gray-100 text-gray-600"
+	case room.IsClosed:
+		return "closed", "bg-yellow-100 text-yellow-800"
+	default:
+		return "募集中", "bg-green-100 text-green-800"
+	}
+}
+
+// adminUserName 表示名 → ユーザー名 → ID 先頭8桁の順でフォールバックする
+func adminUserName(userID *uuid.UUID, user *models.User) string {
+	if user != nil {
+		if user.DisplayName != "" {
+			return user.DisplayName
+		}
+		if user.Username != nil && *user.Username != "" {
+			return *user.Username
+		}
+	}
+	if userID == nil {
+		return "システム"
+	}
+	return userID.String()[:8]
+}
+
+// adminLogDetail RoomLog.Details の代表的なキーを表示用文字列にする
+func adminLogDetail(details models.JSONB) string {
+	data, ok := details.Data.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+
+	parts := make([]string, 0, 2)
+	for _, key := range []string{"user_name", "room_name", "reason", "admin_name"} {
+		if v, ok := data[key].(string); ok && v != "" {
+			parts = append(parts, v)
+		}
+	}
+
+	detail := ""
+	for i, p := range parts {
+		if i > 0 {
+			detail += " / "
+		}
+		detail += p
+	}
+	return detail
+}
+
+// formatAdminTime 管理画面用に JST で日時を整形する
+func formatAdminTime(t time.Time) string {
+	return t.In(adminJST).Format("2006-01-02 15:04")
+}

--- a/internal/handlers/admin_test.go
+++ b/internal/handlers/admin_test.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"mhp-rooms/internal/models"
+	"mhp-rooms/internal/view"
+)
+
+func TestAdminRoomStatus(t *testing.T) {
+	inactive := models.DismissReasonInactive
+
+	tests := []struct {
+		name string
+		room models.Room
+		want string
+	}{
+		{"募集中", models.Room{IsActive: true}, "募集中"},
+		{"closed", models.Room{IsActive: true, IsClosed: true}, "closed"},
+		{"ホストによる解散", models.Room{IsActive: false}, "解散"},
+		{"自動解散", models.Room{IsActive: false, DismissReason: &inactive}, "自動解散"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			label, class := adminRoomStatus(&tt.room)
+			if label != tt.want {
+				t.Errorf("label = %q, want %q", label, tt.want)
+			}
+			if class == "" {
+				t.Error("class が空")
+			}
+		})
+	}
+}
+
+func TestBuildAdminLogRows(t *testing.T) {
+	userID := uuid.New()
+	userName := "hunter"
+	logs := []models.RoomLog{
+		{
+			BaseModel: models.BaseModel{CreatedAt: time.Date(2026, 8, 20, 3, 0, 0, 0, time.UTC)},
+			RoomID:    uuid.New(),
+			UserID:    &userID,
+			Action:    "kick",
+			Room:      models.Room{Name: "テスト部屋"},
+			User:      &models.User{Username: &userName},
+			Details:   models.JSONB{Data: map[string]interface{}{"user_name": "対象者"}},
+		},
+		{
+			BaseModel: models.BaseModel{CreatedAt: time.Date(2026, 8, 20, 3, 0, 0, 0, time.UTC)},
+			RoomID:    uuid.New(),
+			Action:    "auto_dismiss", // UserID なし = システムによる操作
+			Room:      models.Room{Name: "放置部屋"},
+		},
+		{
+			BaseModel: models.BaseModel{CreatedAt: time.Date(2026, 8, 20, 3, 0, 0, 0, time.UTC)},
+			RoomID:    uuid.New(),
+			Action:    "unknown_action",
+			Room:      models.Room{Name: "部屋"},
+		},
+	}
+
+	rows := buildAdminLogRows(logs)
+	if len(rows) != 3 {
+		t.Fatalf("rows = %d 件, want 3", len(rows))
+	}
+
+	if rows[0].ActionLabel != "キック" || rows[0].ActorName != "hunter" || rows[0].Detail != "対象者" {
+		t.Errorf("キック行が想定と異なる: %+v", rows[0])
+	}
+	// UTC 03:00 は JST 12:00 で表示される
+	if rows[0].CreatedAt != "2026-08-20 12:00" {
+		t.Errorf("CreatedAt = %q, want JST 表示", rows[0].CreatedAt)
+	}
+	if rows[1].ActionLabel != "自動解散" || rows[1].ActorName != "システム" {
+		t.Errorf("自動解散行が想定と異なる: %+v", rows[1])
+	}
+	// 未知のアクションは生の値をそのまま表示する
+	if rows[2].ActionLabel != "unknown_action" {
+		t.Errorf("未知アクションのラベル = %q", rows[2].ActionLabel)
+	}
+}
+
+func TestBuildAdminRoomRows(t *testing.T) {
+	hostA := uuid.New()
+	hostB := uuid.New()
+	rooms := []models.Room{
+		{
+			BaseModel:      models.BaseModel{ID: uuid.New()},
+			Name:           "通報あり部屋",
+			HostUserID:     hostA,
+			CurrentPlayers: 2,
+			MaxPlayers:     4,
+			IsActive:       true,
+			GameVersion:    models.GameVersion{Code: "MHP2G"},
+			Host:           models.User{DisplayName: "ホストA"},
+		},
+		{
+			BaseModel:   models.BaseModel{ID: uuid.New()},
+			Name:        "通報なし部屋",
+			HostUserID:  hostB,
+			IsActive:    true,
+			GameVersion: models.GameVersion{Code: "MHP3"},
+			Host:        models.User{DisplayName: "ホストB"},
+		},
+	}
+	counts := map[uuid.UUID]int64{hostA: 3}
+
+	rows := buildAdminRoomRows(rooms, counts)
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d 件, want 2", len(rows))
+	}
+	if rows[0].ReportCount != 3 || rows[1].ReportCount != 0 {
+		t.Errorf("通報数が想定と異なる: %d, %d", rows[0].ReportCount, rows[1].ReportCount)
+	}
+	if rows[0].Players != "2/4" || rows[0].GameVersion != "MHP2G" || rows[0].HostName != "ホストA" {
+		t.Errorf("行の内容が想定と異なる: %+v", rows[0])
+	}
+}
+
+func TestAdminUserName(t *testing.T) {
+	id := uuid.New()
+	username := "hunter"
+
+	if got := adminUserName(&id, &models.User{DisplayName: "表示名"}); got != "表示名" {
+		t.Errorf("表示名優先のはずが %q", got)
+	}
+	if got := adminUserName(&id, &models.User{Username: &username}); got != "hunter" {
+		t.Errorf("ユーザー名フォールバックのはずが %q", got)
+	}
+	if got := adminUserName(&id, nil); got != id.String()[:8] {
+		t.Errorf("ID 先頭8桁のはずが %q", got)
+	}
+	if got := adminUserName(nil, nil); got != "システム" {
+		t.Errorf("システムのはずが %q", got)
+	}
+}
+
+// TestRenderAdminTemplates 管理画面テンプレートがパース・描画できることを確認する
+func TestRenderAdminTemplates(t *testing.T) {
+	chdirRepoRoot(t)
+
+	roomID := uuid.New()
+	room := &models.Room{
+		BaseModel:      models.BaseModel{ID: roomID},
+		Name:           "テスト部屋",
+		Description:    stringPtrForTest("説明文"),
+		CurrentPlayers: 1,
+		MaxPlayers:     4,
+		IsActive:       true,
+		GameVersion:    models.GameVersion{Code: "MHP2G"},
+		Host:           models.User{DisplayName: "ホスト太郎"},
+	}
+
+	tests := []struct {
+		template string
+		data     interface{}
+		want     []string
+	}{
+		{
+			template: "admin_dashboard.tmpl",
+			data: adminDashboardData{
+				Logs: []adminLogRow{
+					{CreatedAt: "2026-08-20 12:00", ActionLabel: "キック", RoomID: roomID, RoomName: "テスト部屋", ActorName: "hunter", Detail: "対象者"},
+				},
+				Pagination: newPagination(120, 2, adminLogsPerPage, "/admin"),
+			},
+			want: []string{"活動タイムライン", "テスト部屋", "キック", "/admin/rooms/" + roomID.String(), "前へ", "次へ"},
+		},
+		{
+			template: "admin_rooms.tmpl",
+			data: adminRoomsData{
+				Rooms: []adminRoomRow{
+					{ID: roomID, Name: "テスト部屋", GameVersion: "MHP2G", HostName: "ホスト太郎", Players: "1/4", StatusLabel: "募集中", StatusClass: "bg-green-100 text-green-800", ReportCount: 2, CreatedAt: "2026-08-20 12:00"},
+				},
+				Pagination: newPagination(1, 1, adminRoomsPerPage, "/admin/rooms"),
+			},
+			want: []string{"全部屋一覧", "テスト部屋", "2件", "募集中"},
+		},
+		{
+			template: "admin_room_detail.tmpl",
+			data: adminRoomDetailData{
+				Room:        room,
+				StatusLabel: "募集中",
+				StatusClass: "bg-green-100 text-green-800",
+				CreatedAt:   "2026-08-20 12:00",
+				Members: []adminMemberRow{
+					{UserID: uuid.New(), Name: "ホスト太郎", IsHost: true, JoinedAt: "2026-08-20 12:00"},
+				},
+				Messages: []adminMessageRow{
+					{CreatedAt: "2026-08-20 12:01", UserName: "参加者", Message: "よろしく！"},
+				},
+				OlderCursor: uuid.New().String(),
+			},
+			want: []string{"チャットログ", "よろしく！", "ホスト太郎", "さらに古いログ"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.template, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			view.Template(w, tt.template, view.Data{Title: "管理", PageData: tt.data})
+
+			body := w.Body.String()
+			if w.Code != 200 || strings.Contains(body, "Template parsing error") || strings.Contains(body, "Template execution error") {
+				t.Fatalf("status = %d, body:\n%s", w.Code, truncate(body, 1500))
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(body, want) {
+					t.Errorf("描画結果に %q が含まれていない", want)
+				}
+			}
+		})
+	}
+}
+
+func stringPtrForTest(s string) *string {
+	return &s
+}

--- a/internal/middleware/admin.go
+++ b/internal/middleware/admin.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+)
+
+// RequireAdmin 管理者ロールのユーザーのみ許可するミドルウェア。
+// 認証ミドルウェア（JWTAuth.Middleware）の後段に置く前提で、コンテキストの DB ユーザーを参照する。
+// 管理画面の存在を外部に知らせないため、権限がない場合は 403 ではなく 404 を返す
+func RequireAdmin(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, ok := GetDBUserFromContext(r.Context())
+		if !ok || user == nil || !user.IsAdmin() {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/admin_test.go
+++ b/internal/middleware/admin_test.go
@@ -1,0 +1,44 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"mhp-rooms/internal/models"
+)
+
+func TestRequireAdmin(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequireAdmin(next)
+
+	tests := []struct {
+		name string
+		user *models.User
+		want int
+	}{
+		{"コンテキストにユーザーなし（未認証）", nil, http.StatusNotFound},
+		{"一般ユーザー", &models.User{Role: models.RoleUser}, http.StatusNotFound},
+		{"ロールが空", &models.User{}, http.StatusNotFound},
+		{"管理者", &models.User{Role: models.RoleAdmin}, http.StatusOK},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/admin", nil)
+			if tt.user != nil {
+				r = r.WithContext(context.WithValue(r.Context(), DBUserContextKey, tt.user))
+			}
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, r)
+
+			if w.Code != tt.want {
+				t.Errorf("status = %d, want %d", w.Code, tt.want)
+			}
+		})
+	}
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -6,6 +6,12 @@ import (
 	"mhp-rooms/internal/utils"
 )
 
+// ユーザーロール
+const (
+	RoleUser  = "user"
+	RoleAdmin = "admin"
+)
+
 // PlayTimes プレイ時間帯の構造体
 type PlayTimes struct {
 	Weekday string `json:"weekday,omitempty"`
@@ -43,6 +49,11 @@ type User struct {
 }
 
 // GetFavoriteGames お気に入りゲームのリストを取得
+// IsAdmin 管理者ロールかどうかを返す
+func (u *User) IsAdmin() bool {
+	return u.Role == RoleAdmin
+}
+
 func (u *User) GetFavoriteGames() ([]string, error) {
 	if u.FavoriteGames.Data == nil {
 		return []string{}, nil

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -52,6 +52,14 @@ type RoomRepository interface {
 	GetUserRoomStatus(userID uuid.UUID) (string, *models.Room, error) // (status, room, error)
 	GetRoomsByHostUser(userID uuid.UUID, limit, offset int) ([]models.Room, error)
 	CountRoomsByHostUser(userID uuid.UUID) (int64, error)
+	GetAllRoomsForAdmin(limit, offset int) ([]models.Room, error)
+	CountAllRooms() (int64, error)
+}
+
+type RoomLogRepository interface {
+	CreateLog(log *models.RoomLog) error
+	ListRecentLogs(limit, offset int) ([]models.RoomLog, error)
+	CountLogs() (int64, error)
 }
 
 type PlayerNameRepository interface {
@@ -110,6 +118,7 @@ type ReportRepository interface {
 	CheckDuplicateReport(reporterID, reportedID uuid.UUID) (bool, error)
 	AddAttachment(attachment *models.ReportAttachment) error
 	GetAttachmentsByReportID(reportID uuid.UUID) ([]models.ReportAttachment, error)
+	CountReportsByReportedUserIDs(userIDs []uuid.UUID) (map[uuid.UUID]int64, error)
 	DeleteAttachment(id uuid.UUID) error
 	GetReportStatsByUserID(userID uuid.UUID) (map[string]int64, error)
 	SearchReports(params ReportSearchParams) ([]models.UserReport, int64, error)

--- a/internal/repository/report_repository.go
+++ b/internal/repository/report_repository.go
@@ -234,3 +234,29 @@ func (r *reportRepository) BatchUpdateStatus(ids []uuid.UUID, status models.Repo
 		Where("id IN ?", ids).
 		Updates(updates).Error
 }
+
+// CountReportsByReportedUserIDs 指定ユーザーそれぞれが通報された件数を返す
+func (r *reportRepository) CountReportsByReportedUserIDs(userIDs []uuid.UUID) (map[uuid.UUID]int64, error) {
+	counts := make(map[uuid.UUID]int64, len(userIDs))
+	if len(userIDs) == 0 {
+		return counts, nil
+	}
+
+	var rows []struct {
+		ReportedUserID uuid.UUID
+		Count          int64
+	}
+	err := r.db.Model(&models.UserReport{}).
+		Select("reported_user_id, COUNT(*) as count").
+		Where("reported_user_id IN ?", userIDs).
+		Group("reported_user_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		counts[row.ReportedUserID] = row.Count
+	}
+	return counts, nil
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -28,6 +28,7 @@ type Repository struct {
 	Report        ReportRepository
 	Contact       ContactRepository
 	Notification  NotificationRepository
+	RoomLog       RoomLogRepository
 }
 
 func NewRepository(db DBInterface) *Repository {
@@ -46,6 +47,7 @@ func NewRepository(db DBInterface) *Repository {
 		Report:        NewReportRepository(db),
 		Contact:       NewContactRepository(db),
 		Notification:  NewNotificationRepository(db),
+		RoomLog:       NewRoomLogRepository(db),
 	}
 }
 

--- a/internal/repository/room_log_repository.go
+++ b/internal/repository/room_log_repository.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"gorm.io/gorm"
+
+	"mhp-rooms/internal/models"
+)
+
+type roomLogRepository struct {
+	db DBInterface
+}
+
+func NewRoomLogRepository(db DBInterface) RoomLogRepository {
+	return &roomLogRepository{db: db}
+}
+
+func (r *roomLogRepository) CreateLog(log *models.RoomLog) error {
+	return r.db.GetConn().Create(log).Error
+}
+
+// ListRecentLogs 全部屋の操作ログを新しい順で取得（管理画面のタイムライン用）
+func (r *roomLogRepository) ListRecentLogs(limit, offset int) ([]models.RoomLog, error) {
+	var logs []models.RoomLog
+	err := r.db.GetConn().
+		Preload("Room", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "name")
+		}).
+		Preload("User", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "username", "display_name")
+		}).
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&logs).Error
+	return logs, err
+}
+
+func (r *roomLogRepository) CountLogs() (int64, error) {
+	var count int64
+	err := r.db.GetConn().Model(&models.RoomLog{}).Count(&count).Error
+	return count, err
+}

--- a/internal/repository/room_repository.go
+++ b/internal/repository/room_repository.go
@@ -808,3 +808,25 @@ func (r *roomRepository) CountRoomsByHostUser(userID uuid.UUID) (int64, error) {
 
 	return count, nil
 }
+
+// GetAllRoomsForAdmin 管理画面用に解散済み・満室も含む全部屋を新しい順で取得
+func (r *roomRepository) GetAllRoomsForAdmin(limit, offset int) ([]models.Room, error) {
+	var rooms []models.Room
+	err := r.db.GetConn().
+		Preload("GameVersion").
+		Preload("Host", func(db *gorm.DB) *gorm.DB {
+			return db.Select("id", "username", "display_name")
+		}).
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&rooms).Error
+	return rooms, err
+}
+
+// CountAllRooms 全部屋数（解散済み含む）を取得
+func (r *roomRepository) CountAllRooms() (int64, error) {
+	var count int64
+	err := r.db.GetConn().Model(&models.Room{}).Count(&count).Error
+	return count, err
+}

--- a/internal/view/render.go
+++ b/internal/view/render.go
@@ -68,6 +68,7 @@ func Template(w http.ResponseWriter, templateName string, data Data) {
 		filepath.Join("templates", "components", "follow_buttons.tmpl"),
 		filepath.Join("templates", "components", "block_report_buttons.tmpl"),
 		filepath.Join("templates", "components", "report_modal.tmpl"),
+		filepath.Join("templates", "components", "admin_nav.tmpl"),
 		filepath.Join("templates", "pages", templateName),
 	)
 	if err != nil {

--- a/templates/components/admin_nav.tmpl
+++ b/templates/components/admin_nav.tmpl
@@ -1,0 +1,60 @@
+{{ define "admin_nav" }}
+  <section class="bg-white py-6 border-b border-gray-200">
+    <div class="container mx-auto px-4">
+      <div class="flex items-center justify-between">
+        <div>
+          <h1 class="text-2xl font-bold text-gray-800">管理画面</h1>
+          <p class="text-sm text-gray-500 mt-1">
+            閲覧専用です。閲覧操作は監査ログに記録されます
+          </p>
+        </div>
+      </div>
+      <nav class="mt-4 flex gap-2">
+        <a
+          href="/admin"
+          class="px-4 py-2 rounded-md text-sm font-medium transition-colors {{ if eq . "dashboard" }}
+            bg-gray-800 text-white
+          {{ else }}
+            bg-gray-100 text-gray-700 hover:bg-gray-200
+          {{ end }}"
+        >
+          タイムライン
+        </a>
+        <a
+          href="/admin/rooms"
+          class="px-4 py-2 rounded-md text-sm font-medium transition-colors {{ if eq . "rooms" }}
+            bg-gray-800 text-white
+          {{ else }}
+            bg-gray-100 text-gray-700 hover:bg-gray-200
+          {{ end }}"
+        >
+          部屋一覧
+        </a>
+      </nav>
+    </div>
+  </section>
+{{ end }}
+
+{{ define "admin_pagination" }}
+  {{ if gt .TotalPages 1 }}
+    <div class="mt-6 flex items-center justify-center gap-3 text-sm">
+      {{ if gt .CurrentPage 1 }}
+        <a
+          href="{{ .BaseURL }}?page={{ sub .CurrentPage 1 }}"
+          class="px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+          >前へ</a
+        >
+      {{ end }}
+      <span class="text-gray-500">
+        {{ .CurrentPage }} / {{ .TotalPages }} ページ（全{{ .Total }}件）
+      </span>
+      {{ if lt .CurrentPage .TotalPages }}
+        <a
+          href="{{ .BaseURL }}?page={{ add .CurrentPage 1 }}"
+          class="px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+          >次へ</a
+        >
+      {{ end }}
+    </div>
+  {{ end }}
+{{ end }}

--- a/templates/pages/admin_dashboard.tmpl
+++ b/templates/pages/admin_dashboard.tmpl
@@ -1,0 +1,64 @@
+{{ define "head" }}
+  <meta name="robots" content="noindex, nofollow" />
+{{ end }}
+
+{{ define "page" }}
+  <div class="min-h-[calc(100vh-4rem)]">
+    {{ template "admin_nav" "dashboard" }}
+
+
+    <section class="py-8">
+      <div class="container mx-auto px-4">
+        <h2 class="text-lg font-bold text-gray-800 mb-4">活動タイムライン</h2>
+
+        {{ if .PageData.Logs }}
+          <div
+            class="bg-white border border-gray-200 rounded-lg overflow-x-auto"
+          >
+            <table class="w-full text-sm">
+              <thead>
+                <tr
+                  class="text-left text-xs text-gray-500 border-b border-gray-200 bg-gray-50"
+                >
+                  <th class="px-4 py-3 whitespace-nowrap">日時</th>
+                  <th class="px-4 py-3 whitespace-nowrap">アクション</th>
+                  <th class="px-4 py-3">部屋</th>
+                  <th class="px-4 py-3">実行者</th>
+                  <th class="px-4 py-3">詳細</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                {{ range .PageData.Logs }}
+                  <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap">
+                      {{ .CreatedAt }}
+                    </td>
+                    <td class="px-4 py-3 whitespace-nowrap">
+                      <span
+                        class="inline-block px-2 py-0.5 rounded-full text-xs bg-gray-100 text-gray-700"
+                        >{{ .ActionLabel }}</span
+                      >
+                    </td>
+                    <td class="px-4 py-3">
+                      <a
+                        href="/admin/rooms/{{ .RoomID }}"
+                        class="text-blue-600 hover:underline"
+                        >{{ .RoomName }}</a
+                      >
+                    </td>
+                    <td class="px-4 py-3 text-gray-700">{{ .ActorName }}</td>
+                    <td class="px-4 py-3 text-gray-500">{{ .Detail }}</td>
+                  </tr>
+                {{ end }}
+              </tbody>
+            </table>
+          </div>
+        {{ else }}
+          <p class="text-gray-500 py-8 text-center">ログがまだありません</p>
+        {{ end }}
+
+        {{ template "admin_pagination" .PageData.Pagination }}
+      </div>
+    </section>
+  </div>
+{{ end }}

--- a/templates/pages/admin_room_detail.tmpl
+++ b/templates/pages/admin_room_detail.tmpl
@@ -1,0 +1,127 @@
+{{ define "head" }}
+  <meta name="robots" content="noindex, nofollow" />
+{{ end }}
+
+{{ define "page" }}
+  <div class="min-h-[calc(100vh-4rem)]">
+    {{ template "admin_nav" "rooms" }}
+
+
+    <section class="py-8">
+      <div class="container mx-auto px-4">
+        <div class="mb-6">
+          <a href="/admin/rooms" class="text-sm text-blue-600 hover:underline"
+            >← 部屋一覧に戻る</a
+          >
+        </div>
+
+        <!-- 部屋情報 -->
+        <div class="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <h2 class="text-xl font-bold text-gray-800 break-all">
+                {{ .PageData.Room.Name }}
+              </h2>
+              <p class="text-sm text-gray-500 mt-1">
+                {{ .PageData.Room.GameVersion.Code }} ・ ホスト:
+                {{ .PageData.Room.Host.DisplayName }} ・ 作成:
+                {{ .PageData.CreatedAt }}
+                {{ if .PageData.DismissedAt }}
+                  ・ 解散:
+                  {{ .PageData.DismissedAt }}
+                {{ end }}
+              </p>
+              {{ if .PageData.Room.Description }}
+                <p class="text-sm text-gray-600 mt-2">
+                  {{ .PageData.Room.Description }}
+                </p>
+              {{ end }}
+            </div>
+            <span
+              class="inline-block px-3 py-1 rounded-full text-sm flex-shrink-0 {{ .PageData.StatusClass }}"
+              >{{ .PageData.StatusLabel }}</span
+            >
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <!-- メンバー -->
+          <div class="bg-white border border-gray-200 rounded-lg p-6">
+            <h3 class="text-base font-bold text-gray-800 mb-4">
+              メンバー（{{ len .PageData.Members }}人）
+            </h3>
+            {{ if .PageData.Members }}
+              <ul class="space-y-3">
+                {{ range .PageData.Members }}
+                  <li class="flex items-center justify-between gap-2 text-sm">
+                    <div class="min-w-0">
+                      <a
+                        href="/users/{{ .UserID }}"
+                        class="text-blue-600 hover:underline"
+                        >{{ .Name }}</a
+                      >
+                      {{ if .IsHost }}
+                        <span
+                          class="ml-1 inline-block px-1.5 py-0.5 rounded text-xs bg-gray-800 text-white"
+                          >ホスト</span
+                        >
+                      {{ end }}
+                    </div>
+                    <span class="text-xs text-gray-400 whitespace-nowrap"
+                      >{{ .JoinedAt }}</span
+                    >
+                  </li>
+                {{ end }}
+              </ul>
+            {{ else }}
+              <p class="text-sm text-gray-400">
+                アクティブなメンバーはいません
+              </p>
+            {{ end }}
+          </div>
+
+          <!-- チャットログ -->
+          <div
+            class="bg-white border border-gray-200 rounded-lg p-6 lg:col-span-2"
+          >
+            <h3 class="text-base font-bold text-gray-800 mb-4">チャットログ</h3>
+
+            {{ if .PageData.OlderCursor }}
+              <div class="mb-4 text-center">
+                <a
+                  href="/admin/rooms/{{ .PageData.Room.ID }}?before={{ .PageData.OlderCursor }}"
+                  class="text-sm text-blue-600 hover:underline"
+                  >← さらに古いログを見る</a
+                >
+              </div>
+            {{ end }}
+
+            {{ if .PageData.Messages }}
+              <ul class="space-y-3">
+                {{ range .PageData.Messages }}
+                  <li class="text-sm">
+                    <div class="flex items-baseline gap-2">
+                      <span class="font-medium text-gray-800"
+                        >{{ .UserName }}</span
+                      >
+                      <span class="text-xs text-gray-400"
+                        >{{ .CreatedAt }}</span
+                      >
+                    </div>
+                    <p
+                      class="text-gray-700 mt-0.5 break-all whitespace-pre-wrap"
+                    >
+                      {{ .Message }}
+                    </p>
+                  </li>
+                {{ end }}
+              </ul>
+            {{ else }}
+              <p class="text-sm text-gray-400">メッセージはありません</p>
+            {{ end }}
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+{{ end }}

--- a/templates/pages/admin_rooms.tmpl
+++ b/templates/pages/admin_rooms.tmpl
@@ -1,0 +1,83 @@
+{{ define "head" }}
+  <meta name="robots" content="noindex, nofollow" />
+{{ end }}
+
+{{ define "page" }}
+  <div class="min-h-[calc(100vh-4rem)]">
+    {{ template "admin_nav" "rooms" }}
+
+
+    <section class="py-8">
+      <div class="container mx-auto px-4">
+        <h2 class="text-lg font-bold text-gray-800 mb-4">
+          全部屋一覧（解散済み含む）
+        </h2>
+
+        {{ if .PageData.Rooms }}
+          <div
+            class="bg-white border border-gray-200 rounded-lg overflow-x-auto"
+          >
+            <table class="w-full text-sm">
+              <thead>
+                <tr
+                  class="text-left text-xs text-gray-500 border-b border-gray-200 bg-gray-50"
+                >
+                  <th class="px-4 py-3">部屋名</th>
+                  <th class="px-4 py-3 whitespace-nowrap">ゲーム</th>
+                  <th class="px-4 py-3">ホスト</th>
+                  <th class="px-4 py-3 whitespace-nowrap">人数</th>
+                  <th class="px-4 py-3 whitespace-nowrap">状態</th>
+                  <th class="px-4 py-3 whitespace-nowrap">ホストへの通報</th>
+                  <th class="px-4 py-3 whitespace-nowrap">作成日時</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                {{ range .PageData.Rooms }}
+                  <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3">
+                      <a
+                        href="/admin/rooms/{{ .ID }}"
+                        class="text-blue-600 hover:underline font-medium"
+                        >{{ .Name }}</a
+                      >
+                    </td>
+                    <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
+                      {{ .GameVersion }}
+                    </td>
+                    <td class="px-4 py-3 text-gray-700">{{ .HostName }}</td>
+                    <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
+                      {{ .Players }}
+                    </td>
+                    <td class="px-4 py-3 whitespace-nowrap">
+                      <span
+                        class="inline-block px-2 py-0.5 rounded-full text-xs {{ .StatusClass }}"
+                        >{{ .StatusLabel }}</span
+                      >
+                    </td>
+                    <td class="px-4 py-3 whitespace-nowrap">
+                      {{ if gt .ReportCount 0 }}
+                        <span
+                          class="inline-block px-2 py-0.5 rounded-full text-xs bg-red-100 text-red-700 font-medium"
+                          >{{ .ReportCount }}件</span
+                        >
+                      {{ else }}
+                        <span class="text-gray-400">-</span>
+                      {{ end }}
+                    </td>
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap">
+                      {{ .CreatedAt }}
+                    </td>
+                  </tr>
+                {{ end }}
+              </tbody>
+            </table>
+          </div>
+        {{ else }}
+          <p class="text-gray-500 py-8 text-center">部屋がまだありません</p>
+        {{ end }}
+
+        {{ template "admin_pagination" .PageData.Pagination }}
+      </div>
+    </section>
+  </div>
+{{ end }}


### PR DESCRIPTION
## リリース内容
- 管理者向け管理画面フェーズ1（#192 / PR #193）
  - `/admin` 活動タイムライン、`/admin/rooms` 全部屋一覧（ホストへの通報数付き）、`/admin/rooms/{id}` 閲覧専用の部屋詳細（チャットログ）
  - `users.role = 'admin'` のユーザーのみアクセス可（それ以外は 404、未ログインはログインへリダイレクト）
  - 部屋詳細の閲覧は監査ログ（admin_view）に記録
- ステージング URL（stg.huntershub.net）のドキュメント追記

## ステージングでの確認
- huntershub-stg-00040-2fk で管理画面の表示・監査ログ・非管理者 404 を確認済み

## デプロイ後の作業
- 本番 DB で管理者を付与:
  ```sql
  UPDATE users SET role = 'admin' WHERE email = '<管理者のメールアドレス>';
  ```
- https://huntershub.net/admin で表示確認（未ログイン時はログインへリダイレクトされること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)