### PR TITLE
fix: 未設定ユーザーの表示名とプロフィール表示を修正

### DIFF
--- a/internal/handlers/profile_tabs_render_test.go
+++ b/internal/handlers/profile_tabs_render_test.go
@@ -236,3 +236,78 @@ func TestRenderPagesIncludeNotificationUI(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderUnconfiguredUserProfileUsesFallbackName(t *testing.T) {
+	chdirRepoRoot(t)
+
+	username := "@fallback-user"
+	bio := "自己紹介は設定済みです。"
+	user := &models.User{
+		BaseModel:   models.BaseModel{ID: uuid.MustParse("12345678-1234-1234-1234-123456789abc")},
+		DisplayName: "  ",
+		Username:    &username,
+		Bio:         &bio,
+	}
+	profileData := UserProfileData{
+		User:            user,
+		IsAuthenticated: true,
+		RelationStatus:  "following",
+		PlayTimes:       &models.PlayTimes{},
+		RoomsPagination: newPagination(0, 1, tabPerPage, "/api/users/123/rooms"),
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/users/12345678-1234-1234-1234-123456789abc", nil)
+	renderTemplate(w, r, "user_profile.tmpl", TemplateData{
+		Title:    "@fallback-userのプロフィール",
+		PageData: profileData,
+	})
+
+	body := w.Body.String()
+	if w.Code != 200 || strings.Contains(body, "Template parsing error") || strings.Contains(body, "Template execution error") {
+		t.Fatalf("status = %d, body:\n%s", w.Code, truncate(body, 1500))
+	}
+	for _, want := range []string{
+		"<title>@fallback-userのプロフィール - HuntersHub</title>",
+		"\n                @fallback-user\n              </h2>",
+		`alt="@fallback-user のアバター"`,
+		"自己紹介は設定済みです。",
+		"プロフィールはまだ設定されていません。",
+		"showUnfollowModal('12345678-1234-1234-1234-123456789abc', '@fallback-user')",
+		"userName: '@fallback-user'",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("描画結果に %q が含まれていない:\n%s", want, body)
+		}
+	}
+
+	partialData := struct {
+		User            *models.User
+		IsOwnProfile    bool
+		IsAuthenticated bool
+		RelationStatus  string
+		AvatarURL       string
+	}{
+		User:            user,
+		IsAuthenticated: true,
+		RelationStatus:  "following",
+		AvatarURL:       "/static/images/default-avatar.webp",
+	}
+	partialWriter := httptest.NewRecorder()
+	if err := renderPartialTemplate(partialWriter, "profile_card_content", partialData); err != nil {
+		t.Fatalf("renderPartialTemplate() error = %v", err)
+	}
+	partialBody := partialWriter.Body.String()
+	for _, want := range []string{
+		">@fallback-user</h2>",
+		`alt="@fallback-user のアバター"`,
+		"自己紹介は設定済みです。",
+		"プロフィールはまだ設定されていません。",
+		"showUnfollowModal('12345678-1234-1234-1234-123456789abc', '@fallback-user')",
+		"userName: '@fallback-user'",
+	} {
+		if !strings.Contains(partialBody, want) {
+			t.Errorf("部分更新の描画結果に %q が含まれていない:\n%s", want, partialBody)
+		}
+	}
+}

--- a/internal/handlers/recent_activity_test.go
+++ b/internal/handlers/recent_activity_test.go
@@ -2,8 +2,11 @@ package handlers
 
 import (
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"mhp-rooms/internal/models"
 
 	"github.com/google/uuid"
 )
@@ -32,5 +35,40 @@ func TestRenderRecentActivityFeedPartial(t *testing.T) {
 	}
 	if w.Code != 200 || w.Body.Len() == 0 {
 		t.Fatalf("フィード描画に失敗: %d", w.Code)
+	}
+}
+
+func TestRenderRecentActivityFeedUsesFallbackDisplayName(t *testing.T) {
+	chdirRepoRoot(t)
+
+	w := httptest.NewRecorder()
+	data := RecentActivityFeedData{Activities: []RecentActivityItem{{
+		UserID:      uuid.New(),
+		DisplayName: "@fallback-user",
+		Title:       "部屋を作成",
+		Type:        "room_create",
+		TimeAgo:     "1分前",
+	}}}
+	if err := renderPartialTemplate(w, "recent_activity_feed", data); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(w.Body.String(), ">@fallback-user</a") {
+		t.Errorf("フォールバック表示名が描画されていない:\n%s", w.Body.String())
+	}
+}
+
+func TestRecentActivityItemUsesUsernameWhenDisplayNameIsEmpty(t *testing.T) {
+	userID := uuid.MustParse("12345678-1234-5678-9abc-def012345678")
+	username := "  fallback-user  "
+	activity := models.UserActivity{
+		User: models.User{
+			BaseModel:   models.BaseModel{ID: userID},
+			DisplayName: "  ",
+			Username:    &username,
+		},
+	}
+
+	if got := recentActivityItem(activity).DisplayName; got != "@fallback-user" {
+		t.Errorf("recentActivityItem().DisplayName = %q, want %q", got, "@fallback-user")
 	}
 }

--- a/internal/handlers/rooms.go
+++ b/internal/handlers/rooms.go
@@ -81,18 +81,22 @@ func (h *RoomHandler) RecentActivity(w http.ResponseWriter, r *http.Request) {
 	}
 	items := make([]RecentActivityItem, 0, len(activities))
 	for _, activity := range activities {
-		items = append(items, RecentActivityItem{
-			UserID:      activity.User.ID,
-			DisplayName: activity.User.DisplayName,
-			AvatarURL:   activity.User.AvatarURL,
-			Title:       activity.Title,
-			TimeAgo:     formatRelativeTime(activity.CreatedAt),
-			Type:        activity.ActivityType,
-		})
+		items = append(items, recentActivityItem(activity))
 	}
 	if err := renderPartialTemplate(w, "recent_activity_feed", RecentActivityFeedData{Activities: items, WeeklyRoomCount: weeklyRoomCount}); err != nil {
 		log.Printf("最近のうごき描画エラー: %v", err)
 		http.Error(w, "最近のうごきの表示に失敗しました", http.StatusInternalServerError)
+	}
+}
+
+func recentActivityItem(activity models.UserActivity) RecentActivityItem {
+	return RecentActivityItem{
+		UserID:      activity.User.ID,
+		DisplayName: utils.ResolvePublicDisplayName(activity.User.DisplayName, activity.User.Username, activity.User.ID),
+		AvatarURL:   activity.User.AvatarURL,
+		Title:       activity.Title,
+		TimeAgo:     formatRelativeTime(activity.CreatedAt),
+		Type:        activity.ActivityType,
 	}
 }
 

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -12,6 +12,7 @@ import (
 	"mhp-rooms/internal/middleware"
 	"mhp-rooms/internal/models"
 	"mhp-rooms/internal/repository"
+	"mhp-rooms/internal/utils"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -207,7 +208,7 @@ func (uh *UserHandler) Show(w http.ResponseWriter, r *http.Request) {
 	}
 
 	data := TemplateData{
-		Title:    user.DisplayName + "のプロフィール",
+		Title:    utils.ResolvePublicDisplayName(user.DisplayName, user.Username, user.ID) + "のプロフィール",
 		PageData: profileData,
 	}
 

--- a/internal/utils/display_name.go
+++ b/internal/utils/display_name.go
@@ -1,0 +1,27 @@
+package utils
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// ResolvePublicDisplayName は公開画面に表示する安全なユーザー名を返します。
+func ResolvePublicDisplayName(displayName string, username *string, userID uuid.UUID) string {
+	if name := strings.TrimSpace(displayName); name != "" {
+		return name
+	}
+
+	if username != nil {
+		name := strings.TrimLeft(strings.TrimSpace(*username), "@")
+		if name != "" {
+			return "@" + name
+		}
+	}
+
+	if userID != uuid.Nil {
+		return "@" + userID.String()[:8]
+	}
+
+	return "@unknown"
+}

--- a/internal/utils/display_name_test.go
+++ b/internal/utils/display_name_test.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestResolvePublicDisplayName(t *testing.T) {
+	userID := uuid.MustParse("12345678-1234-5678-9abc-def012345678")
+	username := "  hunter  "
+	usernameWithAtMark := "  @@hunter  "
+	blankUsername := "  \t"
+
+	tests := []struct {
+		name        string
+		displayName string
+		username    *string
+		userID      uuid.UUID
+		want        string
+	}{
+		{
+			name:        "設定済みの表示名は前後空白を除いて使用する",
+			displayName: "  ハンター太郎  ",
+			username:    &username,
+			userID:      userID,
+			want:        "ハンター太郎",
+		},
+		{
+			name:        "表示名が空白ならユーザー名を使用する",
+			displayName: "  ",
+			username:    &username,
+			userID:      userID,
+			want:        "@hunter",
+		},
+		{
+			name:     "ユーザー名の先頭のアットマークは一つにする",
+			username: &usernameWithAtMark,
+			userID:   userID,
+			want:     "@hunter",
+		},
+		{
+			name:   "ユーザー名がnilならUUID先頭8文字を使用する",
+			userID: userID,
+			want:   "@12345678",
+		},
+		{
+			name:     "ユーザー名が空白ならUUID先頭8文字を使用する",
+			username: &blankUsername,
+			userID:   userID,
+			want:     "@12345678",
+		},
+		{
+			name: "ユーザーIDもなければunknownを使用する",
+			want: "@unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResolvePublicDisplayName(tt.displayName, tt.username, tt.userID); got != tt.want {
+				t.Errorf("ResolvePublicDisplayName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/view/funcs.go
+++ b/internal/view/funcs.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 
 	"mhp-rooms/internal/config"
+	"mhp-rooms/internal/models"
+	"mhp-rooms/internal/utils"
+
+	"github.com/google/uuid"
 )
 
 func toLower(s string) string {
@@ -80,6 +84,17 @@ func safeString(s *string) string {
 
 func hasStringValue(s *string) bool {
 	return s != nil && *s != ""
+}
+
+func profileDisplayName(user *models.User) string {
+	if user == nil {
+		return utils.ResolvePublicDisplayName("", nil, uuid.Nil)
+	}
+	return utils.ResolvePublicDisplayName(user.DisplayName, user.Username, user.ID)
+}
+
+func hasProfileDisplayName(user *models.User) bool {
+	return user != nil && strings.TrimSpace(user.DisplayName) != ""
 }
 
 func jsEscape(s string) string {
@@ -167,25 +182,27 @@ func hunterListURL(query, sort string, page int) string {
 
 func TemplateFuncs() template.FuncMap {
 	return template.FuncMap{
-		"lower":            toLower,
-		"json":             toJSON,
-		"map":              makeMap,
-		"gameVersionColor": GetGameVersionColor,
-		"gameVersionIcon":  gameVersionIconHTML,
-		"gameVersionAbbr":  GetGameVersionAbbreviation,
-		"stringPtr":        safeString,
-		"safeString":       safeString,
-		"hasStringValue":   hasStringValue,
-		"jsEscape":         jsEscape,
-		"jsEscapePtr":      jsEscapePtr,
-		"add":              add,
-		"sub":              sub,
-		"mul":              mul,
-		"min":              min,
-		"sequence":         sequence,
-		"getEnv":           config.GetEnv,
-		"safeHTML":         safeHTMLString,
-		"truncate":         truncateHTML,
-		"hunterListURL":    hunterListURL,
+		"lower":                 toLower,
+		"json":                  toJSON,
+		"map":                   makeMap,
+		"gameVersionColor":      GetGameVersionColor,
+		"gameVersionIcon":       gameVersionIconHTML,
+		"gameVersionAbbr":       GetGameVersionAbbreviation,
+		"stringPtr":             safeString,
+		"safeString":            safeString,
+		"hasStringValue":        hasStringValue,
+		"profileDisplayName":    profileDisplayName,
+		"hasProfileDisplayName": hasProfileDisplayName,
+		"jsEscape":              jsEscape,
+		"jsEscapePtr":           jsEscapePtr,
+		"add":                   add,
+		"sub":                   sub,
+		"mul":                   mul,
+		"min":                   min,
+		"sequence":              sequence,
+		"getEnv":                config.GetEnv,
+		"safeHTML":              safeHTMLString,
+		"truncate":              truncateHTML,
+		"hunterListURL":         hunterListURL,
 	}
 }

--- a/templates/components/block_report_buttons.tmpl
+++ b/templates/components/block_report_buttons.tmpl
@@ -30,7 +30,7 @@
           </button>
           -->
             <button
-              @click="$dispatch('open-report-modal', { userId: '{{ .User.ID }}', userName: '{{ .User.DisplayName }}' })"
+              @click="$dispatch('open-report-modal', { userId: '{{ .User.ID }}', userName: '{{ jsEscape (profileDisplayName .User) }}' })"
               class="w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 flex items-center space-x-2"
             >
               <i class="fa-solid fa-flag text-yellow-500"></i>

--- a/templates/components/follow_buttons.tmpl
+++ b/templates/components/follow_buttons.tmpl
@@ -15,7 +15,7 @@
     {{ else if eq .RelationStatus "following" }}
       <div class="w-full space-y-2">
         <button
-          onclick="showUnfollowModal('{{ .User.ID }}', '{{ .User.DisplayName }}')"
+          onclick="showUnfollowModal('{{ .User.ID }}', '{{ jsEscape (profileDisplayName .User) }}')"
           class="w-full bg-gray-200 hover:bg-gray-300 text-gray-800 font-bold py-2.5 px-4 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2"
         >
           <i class="fa-solid fa-user-check"></i>
@@ -44,7 +44,7 @@
           </span>
         </div>
         <button
-          onclick="showUnfollowModal('{{ .User.ID }}', '{{ .User.DisplayName }}', true)"
+          onclick="showUnfollowModal('{{ .User.ID }}', '{{ jsEscape (profileDisplayName .User) }}', true)"
           class="w-full bg-red-500 hover:bg-red-600 text-white font-bold py-2.5 px-4 rounded-lg transition-colors duration-200 flex items-center justify-center space-x-2"
         >
           <i class="fa-solid fa-user-minus"></i>

--- a/templates/components/profile_card_content.tmpl
+++ b/templates/components/profile_card_content.tmpl
@@ -1,20 +1,26 @@
 {{ define "profile_card_content" }}
+  {{ $displayName := profileDisplayName .User }}
   <div class="flex flex-col items-center">
     <div class="relative">
       <img
         class="w-32 h-32 rounded-full mb-4 border-4 border-white object-cover shadow-sm"
         src="{{ .AvatarURL }}"
-        alt="{{ .User.DisplayName }} のアバター"
+        alt="{{ $displayName }} のアバター"
       />
       <span
         class="absolute bottom-4 right-2 bg-green-500 w-5 h-5 rounded-full border-2 border-white"
         title="オンライン"
       ></span>
     </div>
-    <h2 class="text-2xl font-bold text-gray-800">{{ .User.DisplayName }}</h2>
+    <h2 class="text-2xl font-bold text-gray-800">{{ $displayName }}</h2>
 
     {{ if .User.Bio }}
       <p class="text-center text-gray-600 mb-6 text-sm">{{ .User.Bio }}</p>
+    {{ end }}
+    {{ if not (hasProfileDisplayName .User) }}
+      <p class="text-center text-gray-600 mb-6 text-sm" role="status">
+        プロフィールはまだ設定されていません。
+      </p>
     {{ end }}
 
 

--- a/templates/pages/user_profile.tmpl
+++ b/templates/pages/user_profile.tmpl
@@ -77,6 +77,7 @@
 
 {{ define "page" }}
   {{ $profileData := .PageData }}
+  {{ $displayName := profileDisplayName $profileData.User }}
   <div class="container mx-auto p-4 sm:p-6 md:p-8 max-w-6xl">
     <!-- メインコンテンツ (PCではグリッドレイアウト) -->
     <main class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -92,13 +93,13 @@
                   <img
                     class="w-32 h-32 rounded-full mb-4 border-4 border-white object-cover shadow-sm"
                     src="{{ stringPtr $profileData.User.AvatarURL }}"
-                    alt="{{ $profileData.User.DisplayName }} のアバター"
+                    alt="{{ $displayName }} のアバター"
                   />
                 {{ else }}
                   <img
                     class="w-32 h-32 rounded-full mb-4 border-4 border-white object-cover shadow-sm"
                     src="/static/images/default-avatar.webp"
-                    alt="デフォルトアバター"
+                    alt="{{ $displayName }} のアバター"
                   />
                 {{ end }}
                 <span
@@ -107,12 +108,17 @@
                 ></span>
               </div>
               <h2 class="text-2xl font-bold text-gray-800">
-                {{ $profileData.User.DisplayName }}
+                {{ $displayName }}
               </h2>
 
               {{ if $profileData.User.Bio }}
                 <p class="text-center text-gray-600 mb-6 text-sm">
                   {{ $profileData.User.Bio }}
+                </p>
+              {{ end }}
+              {{ if not (hasProfileDisplayName $profileData.User) }}
+                <p class="text-center text-gray-600 mb-6 text-sm" role="status">
+                  プロフィールはまだ設定されていません。
                 </p>
               {{ end }}
 


### PR DESCRIPTION
## 概要

表示名を設定していないユーザーについて、部屋一覧の「最近のうごき」で名前が空になる問題と、公開プロフィールが空に見える問題を修正します。

Closes #205
Closes #206

## 主な変更

- 公開表示名の共通フォールバック処理を追加
  - 表示名
  - @ユーザー名
  - @ユーザーID先頭8文字
  - @unknown
- 「最近のうごき」に共通フォールバックを適用
- 公開プロフィールのタイトル、見出し、アバターalt、フォロー解除・通報UI、HTMX部分更新に同じ表示名を適用
- 表示名未設定時に「プロフィールはまだ設定されていません。」と表示
- 表示名解決、最近のうごき、通常プロフィール、部分更新の回帰テストを追加

## 確認内容

- `go test ./...`
- `go vet ./...`
- `git diff --check`

すべて成功しています。

## 影響範囲

- UI変更: あり（表示名と未設定案内の文言のみ。レイアウト・CSS変更なし）
- スキーマ変更: なし
- マイグレーション: なし
- seed変更: なし
- スクリーンショット: 文言のみの変更のため未添付