### PR TITLE
feat: 管理画面にユーザー一覧と検索機能を追加

### DIFF
--- a/cmd/server/routes.go
+++ b/cmd/server/routes.go
@@ -188,6 +188,7 @@ func (app *Application) setupAdminRoutes(r chi.Router) {
 		ar.Use(middleware.RequireAdmin)
 
 		ar.Get("/", app.adminHandler.Dashboard)
+		ar.Get("/users", app.adminHandler.Users)
 		ar.Get("/rooms", app.adminHandler.Rooms)
 		ar.Get("/rooms/{id}", app.adminHandler.RoomDetail)
 	})

--- a/internal/handlers/admin.go
+++ b/internal/handlers/admin.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -18,6 +20,7 @@ import (
 const (
 	adminLogsPerPage     = 50
 	adminRoomsPerPage    = 20
+	adminUsersPerPage    = 20
 	adminMessagesPerPage = 50
 
 	// AdminActionView 管理者による部屋閲覧の監査ログ用アクション
@@ -56,6 +59,7 @@ type adminLogRow struct {
 // adminRoomRow 部屋一覧の1行分
 type adminRoomRow struct {
 	ID          uuid.UUID
+	HostUserID  uuid.UUID
 	Name        string
 	GameVersion string
 	HostName    string
@@ -64,6 +68,19 @@ type adminRoomRow struct {
 	StatusClass string
 	ReportCount int64
 	CreatedAt   string
+}
+
+// adminUserRow ユーザー一覧の1行分（メールアドレスは管理画面専用）
+type adminUserRow struct {
+	ID             uuid.UUID
+	DisplayName    string
+	Username       string
+	Email          string
+	Role           string
+	CreatedAt      string
+	RoomCount      int64
+	ReportCount    int64
+	LastActivityAt string
 }
 
 // adminMessageRow 部屋詳細のチャットログ1行分
@@ -90,6 +107,14 @@ type adminDashboardData struct {
 // adminRoomsData 部屋一覧の PageData
 type adminRoomsData struct {
 	Rooms      []adminRoomRow
+	Pagination Pagination
+}
+
+// adminUsersData ユーザー一覧の PageData
+type adminUsersData struct {
+	Users      []adminUserRow
+	Query      string
+	Sort       string
 	Pagination Pagination
 }
 
@@ -138,13 +163,18 @@ func (h *AdminHandler) Dashboard(w http.ResponseWriter, r *http.Request) {
 // Rooms 解散済みも含む全部屋の一覧
 func (h *AdminHandler) Rooms(w http.ResponseWriter, r *http.Request) {
 	page := parsePageParam(r)
+	hostUserID, err := parseAdminRoomsHostUserID(r.URL.Query().Get("host_user_id"))
+	if err != nil {
+		http.Error(w, "host_user_id は有効なUUIDを指定してください", http.StatusBadRequest)
+		return
+	}
 
-	rooms, err := h.repo.Room.GetAllRoomsForAdmin(adminRoomsPerPage, (page-1)*adminRoomsPerPage)
+	rooms, err := h.repo.Room.GetAllRoomsForAdmin(adminRoomsPerPage, (page-1)*adminRoomsPerPage, hostUserID)
 	if err != nil {
 		http.Error(w, "部屋一覧の取得に失敗しました", http.StatusInternalServerError)
 		return
 	}
-	total, err := h.repo.Room.CountAllRooms()
+	total, err := h.repo.Room.CountAllRooms(hostUserID)
 	if err != nil {
 		http.Error(w, "部屋件数の取得に失敗しました", http.StatusInternalServerError)
 		return
@@ -169,11 +199,41 @@ func (h *AdminHandler) Rooms(w http.ResponseWriter, r *http.Request) {
 
 	data := adminRoomsData{
 		Rooms:      buildAdminRoomRows(rooms, reportCounts),
-		Pagination: newPagination(total, page, adminRoomsPerPage, "/admin/rooms"),
+		Pagination: newPaginationWithQuery(total, page, adminRoomsPerPage, "/admin/rooms", adminRoomsQuery(hostUserID)),
 	}
 
 	view.Template(w, "admin_rooms.tmpl", view.Data{
 		Title:    "部屋一覧（管理）",
+		PageData: data,
+	})
+}
+
+// Users は無効化済みも含め、管理者だけにユーザーと集計情報を表示します。
+func (h *AdminHandler) Users(w http.ResponseWriter, r *http.Request) {
+	params := normalizeAdminUserListParams(r.URL.Query().Get("q"), r.URL.Query().Get("sort"))
+	page := parsePageParam(r)
+	params.Limit = adminUsersPerPage
+	params.Offset = (page - 1) * adminUsersPerPage
+
+	users, err := h.repo.User.ListAdminUsers(params)
+	if err != nil {
+		http.Error(w, "ユーザー一覧の取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+	total, err := h.repo.User.CountAdminUsers(params.Query)
+	if err != nil {
+		http.Error(w, "ユーザー件数の取得に失敗しました", http.StatusInternalServerError)
+		return
+	}
+
+	data := adminUsersData{
+		Users:      buildAdminUserRows(users),
+		Query:      params.Query,
+		Sort:       params.Sort,
+		Pagination: newPaginationWithQuery(total, page, adminUsersPerPage, "/admin/users", adminUsersQuery(params)),
+	}
+	view.Template(w, "admin_users.tmpl", view.Data{
+		Title:    "ユーザー一覧（管理）",
 		PageData: data,
 	})
 }
@@ -292,6 +352,7 @@ func buildAdminRoomRows(rooms []models.Room, reportCounts map[uuid.UUID]int64) [
 		statusLabel, statusClass := adminRoomStatus(room)
 		rows = append(rows, adminRoomRow{
 			ID:          room.ID,
+			HostUserID:  room.HostUserID,
 			Name:        room.Name,
 			GameVersion: room.GameVersion.Code,
 			HostName:    adminUserName(&room.HostUserID, &room.Host),
@@ -303,6 +364,76 @@ func buildAdminRoomRows(rooms []models.Room, reportCounts map[uuid.UUID]int64) [
 		})
 	}
 	return rows
+}
+
+func buildAdminUserRows(users []repository.AdminUser) []adminUserRow {
+	rows := make([]adminUserRow, 0, len(users))
+	for _, user := range users {
+		username := "-"
+		if user.Username != nil && *user.Username != "" {
+			username = *user.Username
+		}
+		lastActivityAt := "活動なし"
+		if user.LastActivityAt != nil {
+			lastActivityAt = formatAdminTime(*user.LastActivityAt)
+		}
+		rows = append(rows, adminUserRow{
+			ID:             user.ID,
+			DisplayName:    user.DisplayName,
+			Username:       username,
+			Email:          user.Email,
+			Role:           user.Role,
+			CreatedAt:      formatAdminTime(user.CreatedAt),
+			RoomCount:      user.RoomCount,
+			ReportCount:    user.ReportCount,
+			LastActivityAt: lastActivityAt,
+		})
+	}
+	return rows
+}
+
+func normalizeAdminUserListParams(query, sort string) repository.AdminUserListParams {
+	normalizedQuery := strings.TrimSpace(query)
+	if runes := []rune(normalizedQuery); len(runes) > 100 {
+		normalizedQuery = string(runes[:100])
+	}
+	if sort != "rooms" && sort != "reports" && sort != "joined" {
+		sort = "joined"
+	}
+	return repository.AdminUserListParams{Query: normalizedQuery, Sort: sort}
+}
+
+func adminUsersQuery(params repository.AdminUserListParams) url.Values {
+	values := url.Values{}
+	if params.Query != "" {
+		values.Set("q", params.Query)
+	}
+	values.Set("sort", params.Sort)
+	return values
+}
+
+func parseAdminRoomsHostUserID(value string) (*uuid.UUID, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+
+	parsed, err := uuid.Parse(value)
+	if err != nil {
+		return nil, fmt.Errorf("parse host user ID: %w", err)
+	}
+	if parsed == uuid.Nil {
+		return nil, fmt.Errorf("host user ID must not be nil UUID")
+	}
+	return &parsed, nil
+}
+
+func adminRoomsQuery(hostUserID *uuid.UUID) url.Values {
+	values := url.Values{}
+	if hostUserID != nil {
+		values.Set("host_user_id", hostUserID.String())
+	}
+	return values
 }
 
 func buildAdminMemberRows(members []models.RoomMember) []adminMemberRow {

--- a/internal/handlers/admin_test.go
+++ b/internal/handlers/admin_test.go
@@ -1,14 +1,20 @@
 package handlers
 
 import (
+	"fmt"
+	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 
 	"mhp-rooms/internal/models"
+	"mhp-rooms/internal/repository"
 	"mhp-rooms/internal/view"
 )
 
@@ -142,11 +148,142 @@ func TestAdminUserName(t *testing.T) {
 	}
 }
 
+func TestNormalizeAdminUserListParams(t *testing.T) {
+	longQuery := strings.Repeat("あ", 101)
+	tests := []struct {
+		name      string
+		query     string
+		sort      string
+		wantQuery string
+		wantSort  string
+	}{
+		{"前後の空白を除去", "  hunter  ", "rooms", "hunter", "rooms"},
+		{"100文字に制限", longQuery, "reports", strings.Repeat("あ", 100), "reports"},
+		{"不正な並び順は登録日順", "", "unknown", "", "joined"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeAdminUserListParams(tt.query, tt.sort)
+			if got.Query != tt.wantQuery || got.Sort != tt.wantSort {
+				t.Fatalf("normalizeAdminUserListParams() = %+v, want query=%q sort=%q", got, tt.wantQuery, tt.wantSort)
+			}
+		})
+	}
+}
+
+func TestAdminListPaginationQueries(t *testing.T) {
+	userParams := repository.AdminUserListParams{Query: "room master", Sort: "joined"}
+	userURL := paginationURL("/admin/users", adminUsersQuery(userParams), 2)
+	if want := "/admin/users?page=2&q=room+master&sort=joined"; userURL != want {
+		t.Errorf("ユーザー一覧のページURL = %q, want %q", userURL, want)
+	}
+
+	hostUserID := uuid.New()
+	roomURL := paginationURL("/admin/rooms", adminRoomsQuery(&hostUserID), 3)
+	if want := "/admin/rooms?host_user_id=" + hostUserID.String() + "&page=3"; roomURL != want {
+		t.Errorf("部屋一覧のページURL = %q, want %q", roomURL, want)
+	}
+}
+
+func TestParseAdminRoomsHostUserID(t *testing.T) {
+	validID := uuid.New()
+	tests := []struct {
+		name    string
+		value   string
+		wantNil bool
+		wantErr bool
+	}{
+		{"未指定", "  ", true, false},
+		{"有効なUUID", " " + validID.String() + " ", false, false},
+		{"不正なUUID", "not-a-uuid", true, true},
+		{"nil UUID", uuid.Nil.String(), true, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAdminRoomsHostUserID(tt.value)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if (got == nil) != tt.wantNil {
+				t.Fatalf("ID = %v, wantNil %t", got, tt.wantNil)
+			}
+			if got != nil && *got != validID {
+				t.Errorf("ID = %s, want %s", got, validID)
+			}
+		})
+	}
+}
+
+func TestAdminRoomsRejectsInvalidHostUserID(t *testing.T) {
+	handler := &AdminHandler{}
+	request := httptest.NewRequest(http.MethodGet, "/admin/rooms?host_user_id=not-a-uuid", nil)
+	response := httptest.NewRecorder()
+
+	handler.Rooms(response, request)
+
+	if response.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", response.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAdminUsersRendersSearchResultsAndPreservesListParams(t *testing.T) {
+	chdirRepoRoot(t)
+
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Room{}, &models.UserActivity{}, &models.UserReport{}); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	for i := 0; i < adminUsersPerPage+1; i++ {
+		username := fmt.Sprintf("hunter-%02d", i)
+		user := &models.User{
+			BaseModel:      models.BaseModel{ID: uuid.New(), CreatedAt: now.Add(time.Duration(i) * time.Minute)},
+			SupabaseUserID: uuid.New(),
+			Email:          fmt.Sprintf("hunter-%02d@example.test", i),
+			Username:       &username,
+			DisplayName:    fmt.Sprintf("Hunter %02d", i),
+			IsActive:       i != adminUsersPerPage,
+			Role:           models.RoleUser,
+		}
+		if err := db.Create(user).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	handler := NewAdminHandler(repository.NewRepository(adminHandlerTestDB{conn: db}))
+	request := httptest.NewRequest(http.MethodGet, "/admin/users?q=+HUNTER+&sort=joined", nil)
+	response := httptest.NewRecorder()
+
+	handler.Users(response, request)
+
+	body := response.Body.String()
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, body:\n%s", response.Code, truncate(body, 1500))
+	}
+	for _, want := range []string{
+		"hunter-20@example.test", // 無効ユーザーも表示する
+		`value="HUNTER"`,
+		`<option value="joined" selected>`,
+		`href="/admin/users?page=2&amp;q=HUNTER&amp;sort=joined"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("描画結果に %q が含まれていない", want)
+		}
+	}
+}
+
 // TestRenderAdminTemplates 管理画面テンプレートがパース・描画できることを確認する
 func TestRenderAdminTemplates(t *testing.T) {
 	chdirRepoRoot(t)
 
 	roomID := uuid.New()
+	userID := uuid.New()
 	room := &models.Room{
 		BaseModel:      models.BaseModel{ID: roomID},
 		Name:           "テスト部屋",
@@ -177,11 +314,28 @@ func TestRenderAdminTemplates(t *testing.T) {
 			template: "admin_rooms.tmpl",
 			data: adminRoomsData{
 				Rooms: []adminRoomRow{
-					{ID: roomID, Name: "テスト部屋", GameVersion: "MHP2G", HostName: "ホスト太郎", Players: "1/4", StatusLabel: "募集中", StatusClass: "bg-green-100 text-green-800", ReportCount: 2, CreatedAt: "2026-08-20 12:00"},
+					{ID: roomID, HostUserID: userID, Name: "テスト部屋", GameVersion: "MHP2G", HostName: "ホスト太郎", Players: "1/4", StatusLabel: "募集中", StatusClass: "bg-green-100 text-green-800", ReportCount: 2, CreatedAt: "2026-08-20 12:00"},
 				},
 				Pagination: newPagination(1, 1, adminRoomsPerPage, "/admin/rooms"),
 			},
-			want: []string{"全部屋一覧", "テスト部屋", "2件", "募集中"},
+			want: []string{"全部屋一覧", "テスト部屋", "2件", "募集中", "/users/" + userID.String()},
+		},
+		{
+			template: "admin_users.tmpl",
+			data: adminUsersData{
+				Users: []adminUserRow{{
+					ID: userID, DisplayName: "ハンター太郎", Username: "hunter-taro", Email: "hunter@example.test", Role: models.RoleUser,
+					CreatedAt: "2026-08-20 12:00", RoomCount: 3, ReportCount: 2, LastActivityAt: "2026-08-21 12:00",
+				}},
+				Query: "hunter", Sort: "rooms",
+				Pagination: newPaginationWithQuery(60, 2, adminUsersPerPage, "/admin/users", url.Values{"q": {"hunter"}, "sort": {"rooms"}}),
+			},
+			want: []string{"ユーザーを検索", "hunter@example.test", "/users/" + userID.String(), "/admin/rooms?host_user_id=" + userID.String(), "page=3"},
+		},
+		{
+			template: "admin_users.tmpl",
+			data:     adminUsersData{Sort: "joined", Pagination: newPagination(0, 1, adminUsersPerPage, "/admin/users")},
+			want:     []string{"該当するユーザーが見つかりません", "条件をリセット"},
 		},
 		{
 			template: "admin_room_detail.tmpl",
@@ -223,3 +377,11 @@ func TestRenderAdminTemplates(t *testing.T) {
 func stringPtrForTest(s string) *string {
 	return &s
 }
+
+type adminHandlerTestDB struct {
+	conn *gorm.DB
+}
+
+func (d adminHandlerTestDB) GetConn() *gorm.DB { return d.conn }
+func (d adminHandlerTestDB) Close() error      { return nil }
+func (d adminHandlerTestDB) GetType() string   { return "sqlite" }

--- a/internal/handlers/pagination.go
+++ b/internal/handlers/pagination.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"math"
 	"net/http"
+	"net/url"
 	"strconv"
 )
 
@@ -16,6 +17,29 @@ type Pagination struct {
 	Total       int64  `json:"total"`
 	PerPage     int    `json:"perPage"`
 	BaseURL     string `json:"baseUrl"`
+	PreviousURL string `json:"previousUrl"`
+	NextURL     string `json:"nextUrl"`
+}
+
+// newPaginationWithQuery はクエリパラメータを保ったページ送り情報を組み立てます。
+func newPaginationWithQuery(total int64, page, perPage int, path string, query url.Values) Pagination {
+	pagination := newPagination(total, page, perPage, path)
+	if page > 1 {
+		pagination.PreviousURL = paginationURL(path, query, page-1)
+	}
+	if page < pagination.TotalPages {
+		pagination.NextURL = paginationURL(path, query, page+1)
+	}
+	return pagination
+}
+
+func paginationURL(path string, query url.Values, page int) string {
+	values := make(url.Values, len(query)+1)
+	for key, value := range query {
+		values[key] = append([]string(nil), value...)
+	}
+	values.Set("page", strconv.Itoa(page))
+	return (&url.URL{Path: path, RawQuery: values.Encode()}).String()
 }
 
 // parsePageParam クエリパラメータ page を1以上の整数として返す（未指定・不正値は1）

--- a/internal/repository/admin_users_test.go
+++ b/internal/repository/admin_users_test.go
@@ -1,0 +1,200 @@
+package repository
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"mhp-rooms/internal/models"
+)
+
+type adminUsersTestDB struct{ conn *gorm.DB }
+
+func (d adminUsersTestDB) GetConn() *gorm.DB { return d.conn }
+func (d adminUsersTestDB) Close() error      { return nil }
+func (d adminUsersTestDB) GetType() string   { return "sqlite" }
+
+func TestAdminUserQueries(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Room{}, &models.UserActivity{}, &models.UserReport{}); err != nil {
+		t.Fatal(err)
+	}
+	repo := NewRepository(adminUsersTestDB{conn: db})
+	now := time.Date(2026, 8, 26, 0, 0, 0, 0, time.UTC)
+	username := "room-master"
+	roomHost := newAdminUserTestUser("部屋職人", &username, "rooms@example.test", now.Add(-3*time.Hour))
+	reported := newAdminUserTestUser("通報対象", nil, "reports@example.test", now.Add(-2*time.Hour))
+	inactive := newAdminUserTestUser("休止中", adminUserTestStringPtr("inactive-hunter"), "inactive@example.test", now.Add(-time.Hour))
+	newest := newAdminUserTestUser("新規ユーザー", adminUserTestStringPtr("newest"), "newest@example.test", now)
+	for _, user := range []*models.User{roomHost, reported, inactive, newest} {
+		if err := repo.User.CreateUser(user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := db.Model(inactive).Update("is_active", false).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		room := &models.Room{
+			BaseModel:     models.BaseModel{ID: uuid.New(), CreatedAt: now.Add(time.Duration(i) * time.Minute)},
+			RoomCode:      "ADMIN-ROOM-" + string(rune('A'+i)),
+			Name:          "管理用部屋",
+			GameVersionID: uuid.New(),
+			HostUserID:    roomHost.ID,
+			MaxPlayers:    4,
+			IsActive:      false,
+		}
+		if err := db.Create(room).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for i := 0; i < 3; i++ {
+		report := &models.UserReport{
+			BaseModel:      models.BaseModel{ID: uuid.New(), CreatedAt: now.Add(time.Duration(i) * time.Minute)},
+			ReporterUserID: roomHost.ID,
+			ReportedUserID: reported.ID,
+			Reason:         models.ReasonSpam,
+			Description:    "テスト通報",
+			Status:         models.ReportStatusPending,
+		}
+		if err := db.Create(report).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, activityAt := range []time.Time{now.Add(-4 * time.Hour), now.Add(-30 * time.Minute)} {
+		activity := &models.UserActivity{BaseModel: models.BaseModel{ID: uuid.New(), CreatedAt: activityAt}, UserID: roomHost.ID, ActivityType: models.ActivityRoomCreate, Title: "活動"}
+		if err := db.Create(activity).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		params AdminUserListParams
+		want   uuid.UUID
+	}{
+		{"表示名検索", AdminUserListParams{Query: "休止", Limit: 20}, inactive.ID},
+		{"ユーザー名検索", AdminUserListParams{Query: "ROOM-MASTER", Limit: 20}, roomHost.ID},
+		{"メール検索", AdminUserListParams{Query: "REPORTS@EXAMPLE", Limit: 20}, reported.ID},
+		{"部屋作成数順", AdminUserListParams{Sort: "rooms", Limit: 20}, roomHost.ID},
+		{"通報数順", AdminUserListParams{Sort: "reports", Limit: 20}, reported.ID},
+		{"登録日順", AdminUserListParams{Sort: "joined", Limit: 20}, newest.ID},
+		{"不正な並び順は登録日順", AdminUserListParams{Sort: "unknown", Limit: 20}, newest.ID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			users, err := repo.User.ListAdminUsers(tt.params)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(users) == 0 || users[0].ID != tt.want {
+				t.Fatalf("先頭ユーザー = %#v, want %s", users, tt.want)
+			}
+		})
+	}
+
+	users, err := repo.User.ListAdminUsers(AdminUserListParams{Limit: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users) != 4 {
+		t.Fatalf("全ユーザー数 = %d, want 4", len(users))
+	}
+	var roomHostRow, inactiveRow *AdminUser
+	for i := range users {
+		if users[i].ID == roomHost.ID {
+			roomHostRow = &users[i]
+		}
+		if users[i].ID == inactive.ID {
+			inactiveRow = &users[i]
+		}
+	}
+	if roomHostRow == nil || roomHostRow.RoomCount != 2 || roomHostRow.LastActivityAt == nil || !roomHostRow.LastActivityAt.Equal(now.Add(-30*time.Minute)) {
+		t.Fatalf("部屋ホストの集計 = %#v", roomHostRow)
+	}
+	if inactiveRow == nil || inactiveRow.Username == nil || *inactiveRow.Username != "inactive-hunter" || inactiveRow.RoomCount != 0 || inactiveRow.ReportCount != 0 || inactiveRow.LastActivityAt != nil {
+		t.Fatalf("無効ユーザーまたはゼロ集計 = %#v", inactiveRow)
+	}
+	count, err := repo.User.CountAdminUsers("")
+	if err != nil || count != 4 {
+		t.Fatalf("全ユーザー件数 = %d, err=%v", count, err)
+	}
+	count, err = repo.User.CountAdminUsers("rooms@example")
+	if err != nil || count != 1 {
+		t.Fatalf("メール検索件数 = %d, err=%v", count, err)
+	}
+}
+
+func TestAdminRoomHostFilter(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.GameVersion{}, &models.Room{}); err != nil {
+		t.Fatal(err)
+	}
+	repo := NewRepository(adminUsersTestDB{conn: db})
+	now := time.Date(2026, 8, 26, 0, 0, 0, 0, time.UTC)
+	hostA := newAdminUserTestUser("ホストA", adminUserTestStringPtr("host-a"), "host-a@example.test", now)
+	hostB := newAdminUserTestUser("ホストB", adminUserTestStringPtr("host-b"), "host-b@example.test", now)
+	for _, user := range []*models.User{hostA, hostB} {
+		if err := repo.User.CreateUser(user); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, room := range []*models.Room{
+		{BaseModel: models.BaseModel{ID: uuid.New(), CreatedAt: now}, RoomCode: "HOST-A-1", Name: "ホストAの部屋1", GameVersionID: uuid.New(), HostUserID: hostA.ID, MaxPlayers: 4, IsActive: true},
+		{BaseModel: models.BaseModel{ID: uuid.New(), CreatedAt: now.Add(-time.Minute)}, RoomCode: "HOST-A-2", Name: "ホストAの部屋2", GameVersionID: uuid.New(), HostUserID: hostA.ID, MaxPlayers: 4, IsActive: false},
+		{BaseModel: models.BaseModel{ID: uuid.New(), CreatedAt: now.Add(-2 * time.Minute)}, RoomCode: "HOST-B-1", Name: "ホストBの部屋", GameVersionID: uuid.New(), HostUserID: hostB.ID, MaxPlayers: 4, IsActive: true},
+	} {
+		if err := db.Create(room).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rooms, err := repo.Room.GetAllRoomsForAdmin(20, 0, &hostA.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rooms) != 2 {
+		t.Fatalf("ホストAの部屋数 = %d, want 2", len(rooms))
+	}
+	for _, room := range rooms {
+		if room.HostUserID != hostA.ID {
+			t.Errorf("別ホストの部屋を取得: %+v", room)
+		}
+	}
+
+	count, err := repo.Room.CountAllRooms(&hostA.ID)
+	if err != nil || count != 2 {
+		t.Fatalf("ホストAの部屋件数 = %d, err=%v, want 2", count, err)
+	}
+	count, err = repo.Room.CountAllRooms(nil)
+	if err != nil || count != 3 {
+		t.Fatalf("全部屋件数 = %d, err=%v, want 3", count, err)
+	}
+}
+
+func newAdminUserTestUser(displayName string, username *string, email string, createdAt time.Time) *models.User {
+	return &models.User{
+		BaseModel:      models.BaseModel{ID: uuid.New(), CreatedAt: createdAt, UpdatedAt: createdAt},
+		SupabaseUserID: uuid.New(),
+		Email:          email,
+		Username:       username,
+		DisplayName:    displayName,
+		IsActive:       true,
+		Role:           models.RoleUser,
+	}
+}
+
+func adminUserTestStringPtr(value string) *string {
+	return &value
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -16,6 +16,8 @@ type UserRepository interface {
 	FindUserByEmail(email string) (*models.User, error)
 	UpdateUser(user *models.User) error
 	GetActiveUsers(limit, offset int) ([]models.User, error)
+	ListAdminUsers(params AdminUserListParams) ([]AdminUser, error)
+	CountAdminUsers(query string) (int64, error)
 	ListPublicHunters(params PublicHunterListParams) ([]PublicHunter, error)
 	CountPublicHunters(query string) (int64, error)
 }
@@ -54,8 +56,8 @@ type RoomRepository interface {
 	GetUserRoomStatus(userID uuid.UUID) (string, *models.Room, error) // (status, room, error)
 	GetRoomsByHostUser(userID uuid.UUID, limit, offset int) ([]models.Room, error)
 	CountRoomsByHostUser(userID uuid.UUID) (int64, error)
-	GetAllRoomsForAdmin(limit, offset int) ([]models.Room, error)
-	CountAllRooms() (int64, error)
+	GetAllRoomsForAdmin(limit, offset int, hostUserID *uuid.UUID) ([]models.Room, error)
+	CountAllRooms(hostUserID *uuid.UUID) (int64, error)
 }
 
 type RoomLogRepository interface {

--- a/internal/repository/room_repository.go
+++ b/internal/repository/room_repository.go
@@ -810,14 +810,18 @@ func (r *roomRepository) CountRoomsByHostUser(userID uuid.UUID) (int64, error) {
 }
 
 // GetAllRoomsForAdmin 管理画面用に解散済み・満室も含む全部屋を新しい順で取得
-func (r *roomRepository) GetAllRoomsForAdmin(limit, offset int) ([]models.Room, error) {
+func (r *roomRepository) GetAllRoomsForAdmin(limit, offset int, hostUserID *uuid.UUID) ([]models.Room, error) {
 	var rooms []models.Room
-	err := r.db.GetConn().
+	query := r.db.GetConn().
 		Preload("GameVersion").
 		Preload("Host", func(db *gorm.DB) *gorm.DB {
 			return db.Select("id", "username", "display_name")
 		}).
-		Order("created_at DESC").
+		Order("rooms.created_at DESC")
+	if hostUserID != nil {
+		query = query.Where("rooms.host_user_id = ?", *hostUserID)
+	}
+	err := query.
 		Limit(limit).
 		Offset(offset).
 		Find(&rooms).Error
@@ -825,8 +829,12 @@ func (r *roomRepository) GetAllRoomsForAdmin(limit, offset int) ([]models.Room, 
 }
 
 // CountAllRooms 全部屋数（解散済み含む）を取得
-func (r *roomRepository) CountAllRooms() (int64, error) {
+func (r *roomRepository) CountAllRooms(hostUserID *uuid.UUID) (int64, error) {
 	var count int64
-	err := r.db.GetConn().Model(&models.Room{}).Count(&count).Error
+	query := r.db.GetConn().Model(&models.Room{})
+	if hostUserID != nil {
+		query = query.Where("host_user_id = ?", *hostUserID)
+	}
+	err := query.Count(&count).Error
 	return count, err
 }

--- a/internal/repository/user_repository.go
+++ b/internal/repository/user_repository.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"database/sql/driver"
 	"errors"
 	"fmt"
 	"strings"
@@ -32,6 +33,90 @@ type PublicHunter struct {
 	RecentActivityTitle *string
 	RecentActivityAt    string
 	RoomCreateCount     int64
+}
+
+// AdminUserListParams は管理画面のユーザー一覧の検索・並び替え条件です。
+type AdminUserListParams struct {
+	Query, Sort   string
+	Limit, Offset int
+}
+
+// AdminUser は管理画面だけで使用するユーザー一覧の表示データです。
+// Email は管理者向けテンプレートにのみ渡します。
+type AdminUser struct {
+	ID             uuid.UUID
+	DisplayName    string
+	Username       *string
+	Email          string
+	Role           string
+	CreatedAt      time.Time
+	RoomCount      int64
+	ReportCount    int64
+	LastActivityAt *time.Time
+}
+
+// adminUserRecord はDBからの集計結果を受け取るための内部表現です。
+// SQLite は MAX(created_at) を文字列として返すため、最終活動日時には専用の Scanner を使います。
+type adminUserRecord struct {
+	ID             uuid.UUID
+	DisplayName    string
+	Username       *string
+	Email          string
+	Role           string
+	CreatedAt      time.Time
+	RoomCount      int64
+	ReportCount    int64
+	LastActivityAt nullableAdminTime
+}
+
+type nullableAdminTime struct {
+	Time  time.Time
+	Valid bool
+}
+
+func (t nullableAdminTime) Value() (driver.Value, error) {
+	if !t.Valid {
+		return nil, nil
+	}
+	return t.Time, nil
+}
+
+func (t *nullableAdminTime) Scan(value interface{}) error {
+	t.Time = time.Time{}
+	t.Valid = false
+	if value == nil {
+		return nil
+	}
+
+	var raw string
+	switch value := value.(type) {
+	case time.Time:
+		t.Time = value
+		t.Valid = true
+		return nil
+	case string:
+		raw = value
+	case []byte:
+		raw = string(value)
+	default:
+		return fmt.Errorf("scan admin activity time %T", value)
+	}
+
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999",
+		"2006-01-02 15:04:05",
+	} {
+		parsed, err := time.Parse(layout, raw)
+		if err == nil {
+			t.Time = parsed
+			t.Valid = true
+			return nil
+		}
+	}
+	return fmt.Errorf("parse admin activity time %q", raw)
 }
 
 // NewUserRepository は新しいUserRepositoryインスタンスを作成
@@ -121,6 +206,77 @@ func (r *userRepository) GetActiveUsers(limit, offset int) ([]models.User, error
 		Offset(offset).
 		Find(&users).Error
 	return users, err
+}
+
+// ListAdminUsers は無効化済みを含む管理用ユーザー一覧を集計付きで返します。
+func (r *userRepository) ListAdminUsers(params AdminUserListParams) ([]AdminUser, error) {
+	if params.Limit <= 0 || params.Limit > 100 {
+		params.Limit = 20
+	}
+	if params.Offset < 0 {
+		params.Offset = 0
+	}
+	if params.Sort != "rooms" && params.Sort != "reports" && params.Sort != "joined" {
+		params.Sort = "joined"
+	}
+
+	roomCount := "(SELECT COUNT(*) FROM rooms admin_rooms WHERE admin_rooms.host_user_id = users.id)"
+	reportCount := "(SELECT COUNT(*) FROM user_reports admin_reports WHERE admin_reports.reported_user_id = users.id)"
+	lastActivityAt := "(SELECT MAX(admin_activities.created_at) FROM user_activities admin_activities WHERE admin_activities.user_id = users.id)"
+	query := r.db.GetConn().Model(&models.User{}).Select(
+		"users.id, users.display_name, users.username, users.email, users.role, users.created_at, " + roomCount + " AS room_count, " + reportCount + " AS report_count, " + lastActivityAt + " AS last_activity_at",
+	)
+	if normalized := strings.TrimSpace(params.Query); normalized != "" {
+		like := "%" + strings.ToLower(normalized) + "%"
+		query = query.Where("(LOWER(users.display_name) LIKE ? OR LOWER(COALESCE(users.username, '')) LIKE ? OR LOWER(users.email) LIKE ?)", like, like, like)
+	}
+	switch params.Sort {
+	case "rooms":
+		query = query.Order("room_count DESC, users.created_at DESC, users.id ASC")
+	case "reports":
+		query = query.Order("report_count DESC, users.created_at DESC, users.id ASC")
+	default:
+		query = query.Order("users.created_at DESC, users.id ASC")
+	}
+
+	var records []adminUserRecord
+	if err := query.Limit(params.Limit).Offset(params.Offset).Scan(&records).Error; err != nil {
+		return nil, err
+	}
+	users := make([]AdminUser, 0, len(records))
+	for _, record := range records {
+		var lastActivityAt *time.Time
+		if record.LastActivityAt.Valid {
+			value := record.LastActivityAt.Time
+			lastActivityAt = &value
+		}
+		users = append(users, AdminUser{
+			ID:             record.ID,
+			DisplayName:    record.DisplayName,
+			Username:       record.Username,
+			Email:          record.Email,
+			Role:           record.Role,
+			CreatedAt:      record.CreatedAt,
+			RoomCount:      record.RoomCount,
+			ReportCount:    record.ReportCount,
+			LastActivityAt: lastActivityAt,
+		})
+	}
+	return users, nil
+}
+
+// CountAdminUsers は管理画面の検索条件に一致する全ユーザー数を返します。
+func (r *userRepository) CountAdminUsers(search string) (int64, error) {
+	query := r.db.GetConn().Model(&models.User{})
+	if normalized := strings.TrimSpace(search); normalized != "" {
+		like := "%" + strings.ToLower(normalized) + "%"
+		query = query.Where("(LOWER(display_name) LIKE ? OR LOWER(COALESCE(username, '')) LIKE ? OR LOWER(email) LIKE ?)", like, like, like)
+	}
+	var count int64
+	if err := query.Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 // ListPublicHunters は公開ハンター一覧をN+1なしで取得します。

--- a/templates/components/admin_nav.tmpl
+++ b/templates/components/admin_nav.tmpl
@@ -9,10 +9,11 @@
           </p>
         </div>
       </div>
-      <nav class="mt-4 flex gap-2">
+      <nav class="mt-4 flex flex-wrap gap-2" aria-label="管理画面ナビゲーション">
         <a
           href="/admin"
-          class="px-4 py-2 rounded-md text-sm font-medium transition-colors {{ if eq . "dashboard" }}
+          aria-current="{{ if eq . "dashboard" }}page{{ end }}"
+          class="min-h-11 px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ if eq . "dashboard" }}
             bg-gray-800 text-white
           {{ else }}
             bg-gray-100 text-gray-700 hover:bg-gray-200
@@ -22,13 +23,25 @@
         </a>
         <a
           href="/admin/rooms"
-          class="px-4 py-2 rounded-md text-sm font-medium transition-colors {{ if eq . "rooms" }}
+          aria-current="{{ if eq . "rooms" }}page{{ end }}"
+          class="min-h-11 px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ if eq . "rooms" }}
             bg-gray-800 text-white
           {{ else }}
             bg-gray-100 text-gray-700 hover:bg-gray-200
           {{ end }}"
         >
           部屋一覧
+        </a>
+        <a
+          href="/admin/users"
+          aria-current="{{ if eq . "users" }}page{{ end }}"
+          class="min-h-11 px-4 py-2 rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 {{ if eq . "users" }}
+            bg-gray-800 text-white
+          {{ else }}
+            bg-gray-100 text-gray-700 hover:bg-gray-200
+          {{ end }}"
+        >
+          ユーザー一覧
         </a>
       </nav>
     </div>
@@ -40,8 +53,8 @@
     <div class="mt-6 flex items-center justify-center gap-3 text-sm">
       {{ if gt .CurrentPage 1 }}
         <a
-          href="{{ .BaseURL }}?page={{ sub .CurrentPage 1 }}"
-          class="px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+          href="{{ if .PreviousURL }}{{ .PreviousURL }}{{ else }}{{ .BaseURL }}?page={{ sub .CurrentPage 1 }}{{ end }}"
+          class="inline-flex min-h-11 items-center px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >前へ</a
         >
       {{ end }}
@@ -50,8 +63,8 @@
       </span>
       {{ if lt .CurrentPage .TotalPages }}
         <a
-          href="{{ .BaseURL }}?page={{ add .CurrentPage 1 }}"
-          class="px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
+          href="{{ if .NextURL }}{{ .NextURL }}{{ else }}{{ .BaseURL }}?page={{ add .CurrentPage 1 }}{{ end }}"
+          class="inline-flex min-h-11 items-center px-3 py-2 bg-white border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
           >次へ</a
         >
       {{ end }}

--- a/templates/pages/admin_rooms.tmpl
+++ b/templates/pages/admin_rooms.tmpl
@@ -44,7 +44,9 @@
                     <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
                       {{ .GameVersion }}
                     </td>
-                    <td class="px-4 py-3 text-gray-700">{{ .HostName }}</td>
+                    <td class="px-4 py-3 text-gray-700">
+                      <a href="/users/{{ .HostUserID }}" class="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">{{ .HostName }}</a>
+                    </td>
                     <td class="px-4 py-3 text-gray-700 whitespace-nowrap">
                       {{ .Players }}
                     </td>

--- a/templates/pages/admin_users.tmpl
+++ b/templates/pages/admin_users.tmpl
@@ -1,0 +1,91 @@
+{{ define "head" }}
+  <meta name="robots" content="noindex, nofollow" />
+{{ end }}
+
+{{ define "page" }}
+  <div class="min-h-[calc(100vh-4rem)]">
+    {{ template "admin_nav" "users" }}
+
+    <section class="py-8">
+      <div class="container mx-auto px-4">
+        <div class="flex flex-wrap items-baseline justify-between gap-3 mb-4">
+          <h2 class="text-lg font-bold text-gray-800">ユーザー一覧（無効化済みを含む）</h2>
+          <p class="text-sm text-gray-500">全{{ .PageData.Pagination.Total }}件</p>
+        </div>
+
+        <form action="/admin/users" method="get" class="mb-6 bg-white border border-gray-200 rounded-lg p-4">
+          <div class="grid gap-4 md:grid-cols-[minmax(0,1fr)_14rem_auto] md:items-end">
+            <div>
+              <label for="admin-user-query" class="block mb-1 text-sm font-medium text-gray-700">ユーザーを検索</label>
+              <input
+                id="admin-user-query"
+                name="q"
+                type="search"
+                value="{{ .PageData.Query }}"
+                maxlength="100"
+                placeholder="表示名・ユーザー名・メールアドレス"
+                class="min-h-11 w-full rounded-md border border-gray-300 px-3 text-base text-gray-800 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+              />
+            </div>
+            <div>
+              <label for="admin-user-sort" class="block mb-1 text-sm font-medium text-gray-700">並び順</label>
+              <select id="admin-user-sort" name="sort" class="min-h-11 w-full rounded-md border border-gray-300 px-3 text-base text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">
+                <option value="joined" {{ if eq .PageData.Sort "joined" }}selected{{ end }}>登録日（新しい順）</option>
+                <option value="rooms" {{ if eq .PageData.Sort "rooms" }}selected{{ end }}>部屋作成数（多い順）</option>
+                <option value="reports" {{ if eq .PageData.Sort "reports" }}selected{{ end }}>通報数（多い順）</option>
+              </select>
+            </div>
+            <div class="flex gap-2">
+              <button type="submit" class="min-h-11 rounded-md bg-gray-800 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">検索</button>
+              <a href="/admin/users" class="inline-flex min-h-11 items-center rounded-md border border-gray-300 px-4 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">リセット</a>
+            </div>
+          </div>
+        </form>
+
+        {{ if .PageData.Users }}
+          <div class="bg-white border border-gray-200 rounded-lg overflow-x-auto">
+            <table class="min-w-[860px] w-full text-sm">
+              <thead>
+                <tr class="text-left text-xs text-gray-500 border-b border-gray-200 bg-gray-50">
+                  <th scope="col" class="px-4 py-3">表示名 / ユーザー名</th>
+                  <th scope="col" class="px-4 py-3">メールアドレス</th>
+                  <th scope="col" class="px-4 py-3 whitespace-nowrap">ロール</th>
+                  <th scope="col" class="px-4 py-3 whitespace-nowrap">登録日</th>
+                  <th scope="col" class="px-4 py-3 whitespace-nowrap">部屋作成数</th>
+                  <th scope="col" class="px-4 py-3 whitespace-nowrap">通報数</th>
+                  <th scope="col" class="px-4 py-3 whitespace-nowrap">最終活動</th>
+                </tr>
+              </thead>
+              <tbody class="divide-y divide-gray-100">
+                {{ range .PageData.Users }}
+                  <tr class="hover:bg-gray-50">
+                    <td class="px-4 py-3">
+                      <a href="/users/{{ .ID }}" class="font-medium text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">{{ .DisplayName }}</a>
+                      <p class="mt-1 text-xs text-gray-500">{{ .Username }}</p>
+                    </td>
+                    <td class="px-4 py-3 text-gray-700 whitespace-nowrap">{{ .Email }}</td>
+                    <td class="px-4 py-3 text-gray-700 whitespace-nowrap">{{ .Role }}</td>
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap">{{ .CreatedAt }}</td>
+                    <td class="px-4 py-3 whitespace-nowrap">
+                      <a href="/admin/rooms?host_user_id={{ .ID }}" class="text-blue-600 hover:underline focus:outline-none focus:ring-2 focus:ring-blue-500 rounded">{{ .RoomCount }}件</a>
+                    </td>
+                    <td class="px-4 py-3 text-gray-700 whitespace-nowrap">{{ .ReportCount }}件</td>
+                    <td class="px-4 py-3 text-gray-500 whitespace-nowrap">{{ .LastActivityAt }}</td>
+                  </tr>
+                {{ end }}
+              </tbody>
+            </table>
+          </div>
+        {{ else }}
+          <div class="rounded-lg border border-dashed border-gray-300 bg-white px-6 py-12 text-center">
+            <h3 class="text-base font-semibold text-gray-800">該当するユーザーが見つかりません</h3>
+            <p class="mt-2 text-sm text-gray-500">検索条件を変更するか、条件をリセットしてもう一度確認してください。</p>
+            <a href="/admin/users" class="inline-flex min-h-11 items-center mt-4 rounded-md bg-gray-800 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2">条件をリセット</a>
+          </div>
+        {{ end }}
+
+        {{ template "admin_pagination" .PageData.Pagination }}
+      </div>
+    </section>
+  </div>
+{{ end }}


### PR DESCRIPTION
## 概要

管理者がユーザー単位の利用状況を確認できる、読み取り専用のユーザー一覧を追加します。

Closes #196

## 主な変更

- 管理画面にユーザー一覧・検索・並び替え・ページネーションを追加
- 部屋作成数、通報された数、最終活動日時を集計して表示
- 無効化済みユーザー、NULL username、活動なし、集計0件に対応
- 管理画面の部屋一覧にホストユーザー絞り込みを追加
- 検索・ソート条件をページ移動時に保持
- 管理ナビゲーション、空状態、フォーカス表示などのUIを改善
- repository・handler・テンプレートの回帰テストを追加

## 確認内容

- go test ./...
- go vet ./...
- git diff --check

すべて成功しています。

## 補足

- UI変更: あり（管理画面のみ）
- スキーマ変更: なし
- マイグレーション: なし
- Seed変更: なし